### PR TITLE
Give the appropriate collection+json format to errors raised by serializers with corresponding read-write views.

### DIFF
--- a/chris_backend/collectionjson/services.py
+++ b/chris_backend/collectionjson/services.py
@@ -4,6 +4,8 @@ from urllib.parse import urlparse
 from django.core.urlresolvers import resolve
 
 from rest_framework.response import Response
+from rest_framework import serializers
+
 
 def get_list_response(list_view_instance, queryset):
     """
@@ -58,3 +60,17 @@ def append_collection_querylist(response, query_url_list):
         queries.append({'href': query_url, 'rel': 'search', "data": data})
     response.data["queries"] = queries
     return response
+
+
+def collection_serializer_is_valid(is_valid_method):
+    """
+    Convenience 'is_valid' method decorator to generate a properly formatted message
+    for serializers' validation errors.
+    """
+    def new_is_valid(*args, **kwargs):
+        try:
+            valid = is_valid_method(*args, **kwargs)
+        except serializers.ValidationError as error:
+            raise serializers.ValidationError({'detail': error})
+        return valid
+    return new_is_valid

--- a/chris_backend/feeds/serializers.py
+++ b/chris_backend/feeds/serializers.py
@@ -7,6 +7,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from rest_framework import serializers
 
 from collectionjson.fields import ItemLinkField
+from collectionjson.services import collection_serializer_is_valid
 from .models import Note, Tag, Feed, Comment, FeedFile
 
 
@@ -17,6 +18,13 @@ class NoteSerializer(serializers.HyperlinkedModelSerializer):
         model = Note
         fields = ('url', 'title', 'content', 'feed')
 
+    @collection_serializer_is_valid
+    def is_valid(self, raise_exception=False):
+        """
+        Overriden to generate a properly formatted message for validation errors
+        """
+        return super(NoteSerializer, self).is_valid(raise_exception=raise_exception)
+
 
 class TagSerializer(serializers.HyperlinkedModelSerializer):
     owner = serializers.ReadOnlyField(source='owner.username')
@@ -26,6 +34,13 @@ class TagSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Tag
         fields = ('url', 'name', 'owner', 'color', 'feed')
+
+    @collection_serializer_is_valid
+    def is_valid(self, raise_exception=False):
+        """
+        Overriden to generate a properly formatted message for validation errors
+        """
+        return super(TagSerializer, self).is_valid(raise_exception=raise_exception)
 
 
 class FeedSerializer(serializers.HyperlinkedModelSerializer):
@@ -42,6 +57,13 @@ class FeedSerializer(serializers.HyperlinkedModelSerializer):
         model = Feed
         fields = ('url', 'id', 'creation_date', 'modification_date', 'name', 'owner',
                   'note', 'tags', 'comments', 'files', 'plugin_inst')
+
+    @collection_serializer_is_valid
+    def is_valid(self, raise_exception=False):
+        """
+        Overriden to generate a properly formatted message for validation errors
+        """
+        return super(FeedSerializer, self).is_valid(raise_exception=raise_exception)
 
     def validate_new_owner(self, username):
         """
@@ -63,6 +85,13 @@ class CommentSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Comment
         fields = ('url', 'title', 'owner', 'content', 'feed')
+
+    @collection_serializer_is_valid
+    def is_valid(self, raise_exception=False):
+        """
+        Overriden to generate a properly formatted message for validation errors
+        """
+        return super(CommentSerializer, self).is_valid(raise_exception=raise_exception)
 
 
 class FeedFileSerializer(serializers.HyperlinkedModelSerializer):

--- a/chris_backend/feeds/tests/test_views.py
+++ b/chris_backend/feeds/tests/test_views.py
@@ -719,21 +719,6 @@ class FeedFileDetailViewTests(FeedFileViewTests):
         response = self.client.get(self.read_update_delete_url)
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
-    def test_feedfile_delete_success(self):
-        self.client.login(username=self.username, password=self.password)
-        response = self.client.delete(self.read_update_delete_url)
-        self.assertEquals(response.status_code, status.HTTP_204_NO_CONTENT)
-        self.assertEquals(FeedFile.objects.count(), 0)
-
-    def test_feedfile_delete_failure_unauthenticated(self):
-        response = self.client.delete(self.read_update_delete_url)
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
-
-    def test_feedfile_delete_failure_access_denied(self):
-        self.client.login(username=self.other_username, password=self.other_password)
-        response = self.client.delete(self.read_update_delete_url)
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
 
 class FileResourceViewTests(FeedFileViewTests):
     """

--- a/chris_backend/feeds/views.py
+++ b/chris_backend/feeds/views.py
@@ -289,21 +289,13 @@ class FeedFileList(generics.ListAPIView):
         return self.filter_queryset(feed.files.all())
 
 
-class FeedFileDetail(generics.RetrieveUpdateDestroyAPIView):
+class FeedFileDetail(generics.RetrieveAPIView):
     """
     A feed's file view.
     """
     queryset = FeedFile.objects.all()
     serializer_class = FeedFileSerializer
     permission_classes = (permissions.IsAuthenticated, IsRelatedFeedOwnerOrChris)
-
-    def retrieve(self, request, *args, **kwargs):
-        """
-        Overriden to append a collection+json template.
-        """
-        response = super(FeedFileDetail, self).retrieve(request, *args, **kwargs)
-        template_data = {"fname": ""}
-        return services.append_collection_template(response, template_data)
 
 
 class FileResource(generics.GenericAPIView):

--- a/chris_backend/plugins/serializers.py
+++ b/chris_backend/plugins/serializers.py
@@ -2,6 +2,7 @@
 from django.core.exceptions import ObjectDoesNotExist
 
 from rest_framework import serializers
+from collectionjson.services import collection_serializer_is_valid
 
 from .models import Plugin, PluginParameter, PluginInstance, StringParameter
 from .models import FloatParameter, IntParameter, BoolParameter, PathParameter
@@ -57,6 +58,13 @@ class PluginInstanceSerializer(serializers.HyperlinkedModelSerializer):
         fields = ('url', 'id', 'previous_id', 'plugin_name', 'start_date', 'end_date', 'status',
                   'previous', 'owner', 'feed', 'plugin', 'string_param', 'int_param',
                   'float_param', 'bool_param', 'path_param')
+
+    @collection_serializer_is_valid
+    def is_valid(self, raise_exception=False):
+        """
+        Overriden to generate a properly formatted message for validation errors
+        """
+        return super(PluginInstanceSerializer, self).is_valid(raise_exception=raise_exception)
 
     def validate_previous(self, previous_id, plugin):
         """

--- a/chris_backend/uploadedfiles/serializers.py
+++ b/chris_backend/uploadedfiles/serializers.py
@@ -6,6 +6,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from rest_framework import serializers
 
 from collectionjson.fields import ItemLinkField
+from collectionjson.services import collection_serializer_is_valid
 from .models import UploadedFile
 
 
@@ -19,6 +20,13 @@ class UploadedFileSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = UploadedFile
         fields = ('url', 'upload_path', 'fname', 'file_resource', 'owner')
+
+    @collection_serializer_is_valid
+    def is_valid(self, raise_exception=False):
+        """
+        Overriden to generate a properly formatted message for validation errors
+        """
+        return super(UploadedFileSerializer, self).is_valid(raise_exception=raise_exception)
 
     def _get_file_link(self, obj):
         """

--- a/chris_backend/users/serializers.py
+++ b/chris_backend/users/serializers.py
@@ -3,6 +3,7 @@ from django.contrib.auth.models import User
 
 from rest_framework import serializers
 from rest_framework.validators import UniqueValidator
+from collectionjson.services import collection_serializer_is_valid
 
 
 class UserSerializer(serializers.HyperlinkedModelSerializer):
@@ -16,19 +17,20 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
     password = serializers.CharField(min_length=6, max_length=100, write_only=True)
 
     def create(self, validated_data):
+        """
+        Overriden to save hashed password to the DB.
+        """
         user = User(username=validated_data['username'], email=validated_data['email'])
         user.set_password(validated_data['password'])
         user.save()
         return user
 
+    @collection_serializer_is_valid
     def is_valid(self, raise_exception=False):
         """
-        Overriden to generate a properly formatted message for validation errors
+        Overriden to generate a properly formatted message for validation errors.
         """
-        valid = super(UserSerializer, self).is_valid()
-        if raise_exception and not valid:
-            raise serializers.ValidationError({'detail': str(self._errors)})
-        return valid
+        return super(UserSerializer, self).is_valid(raise_exception=raise_exception)
 
     class Meta:
         model = User

--- a/docker-destroy-chris_dev.sh
+++ b/docker-destroy-chris_dev.sh
@@ -18,9 +18,10 @@ title -d 1 "Stopping the swarm..."
 windowBottom
 
 title -d 1 "Destroying persistent volumes..."
+    basedir=`pwd | xargs basename | awk '{print tolower($0)}'`
     a_PVOLS=(
-        "chrisultronbackend_chris_dev_db_data"
-        "chrisultronbackend_swift_storage"
+        "${basedir//_}_chris_dev_db_data"
+        "${basedir//_}_swift_storage"
     )
     for VOL in ${a_PVOLS[@]} ; do 
         read -p  "Do you want to remove persistent volume $VOL? " -n 1 -r


### PR DESCRIPTION
This fix uncaught serializers error that were generating responses with status code 500 (Internal Server Error) instead of the appropriate 400 (Bad Request). To accomplish this a new **collection_serializer_is_valid** helper decorator was added to the collectionjson django app that is then used to decorate serializers' **is_valid** method in the **feeds, plugins, uploadedfiles and users** django apps.

@danmcp @rudolphpienaar @NicolasRannou This should solve the 500 Internal Server Errors that nico was talking about the other day. 