### PR TITLE
Add Chris Store service to CUBE's compose

### DIFF
--- a/chris_backend/config/settings/local.py
+++ b/chris_backend/config/settings/local.py
@@ -9,7 +9,7 @@ Local settings
 """
 
 from .common import *  # noqa
-import  os
+import os
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
@@ -21,6 +21,14 @@ SECRET_KEY = 'w1kxu^l=@pnsf!5piqz6!!5kdcdpo79y6jebbp+2244yjm*#+k'
 PFCON = {
     'host': 'pfcon_service',
     'port': '5005'
+}
+
+# chris store settings
+CHRIS_STORE = {
+    'host': 'chris_store',
+    'port': '8010',
+    'username': 'cubeadmin',
+    'password': 'cubeadmin1234'
 }
 
 # swift service settings
@@ -38,7 +46,7 @@ DEBUG = True
 CHRIS_DEBUG = {'quiet': True, 'debugFile': '/dev/null', 'useDebug': False}
 
 if 'CHRIS_DEBUG_QUIET' in os.environ:
-    CHRIS_DEBUG['quiet']  = bool(int(os.environ['CHRIS_DEBUG_QUIET']))
+    CHRIS_DEBUG['quiet'] = bool(int(os.environ['CHRIS_DEBUG_QUIET']))
 
 # Database
 # https://docs.djangoproject.com/en/1.9/ref/settings/#databases

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@
 version: '3'
 
 services:
+
   chris_dev:
     image:  ${CREPO}/chris_dev_backend
     volumes:
@@ -23,6 +24,7 @@ services:
       - "8000:8000"
     depends_on:
       - chris_dev_db
+      - chris_store
       - swift_service
       - pfcon_service
     labels:
@@ -41,6 +43,33 @@ services:
     labels:
       name: "ChRIS_ultron_backEnd MySQL Database"
       role: "Backend development database"
+
+  chris_store:
+    image:  ${CREPO}/chris_store
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    ports:
+      - "8010:8010"
+    depends_on:
+      - chris_store_dev_db
+      - swift_service
+    labels:
+      name: "ChRIS_store"
+      role: "Chris store service"
+
+  chris_store_dev_db:
+    # using the dev DB temporary until we switch to a truly production Chris Store
+    image:  mysql:5
+    volumes:
+      - chris_store_dev_db_data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=rootp
+      - MYSQL_DATABASE=chris_store_dev
+      - MYSQL_USER=chris
+      - MYSQL_PASSWORD=Chris1234
+    labels:
+      name: "ChRIS_store MySQL Database"
+      role: "Chris store database"
 
   swift_service:
     image:  fnndsc/docker-swift-onlyone
@@ -107,4 +136,5 @@ services:
 
 volumes:
   chris_dev_db_data:
+  chris_store_dev_db_data:
   swift_storage:

--- a/docker-destroy-chris_dev.sh
+++ b/docker-destroy-chris_dev.sh
@@ -21,6 +21,7 @@ title -d 1 "Destroying persistent volumes..."
     basedir=`pwd | xargs basename | awk '{print tolower($0)}'`
     a_PVOLS=(
         "${basedir//_}_chris_dev_db_data"
+        "${basedir//_}_chris_store_dev_db_data"
         "${basedir//_}_swift_storage"
     )
     for VOL in ${a_PVOLS[@]} ; do 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,6 +3,8 @@ django-filter==0.15.3
 djangorestframework==3.5.3
 django-cors-middleware==1.3.1
 mysqlclient==1.3.9
+requests==2.18.4
+collection-json==0.1.1
 docker==2.1.0
 pfurl==1.3.16.0
 pfmisc==1.2.2

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -4,7 +4,6 @@ django-debug-toolbar==1.5
 django-extensions==1.7.4
 six==1.10.0
 sqlparse==0.2.1
-collection-json==0.1.1
 coverage==4.2
 mod-wsgi-httpd==2.4.12.6
 mod-wsgi==4.5.7


### PR DESCRIPTION
@NicolasRannou @rudolphpienaar @danmcp This adds the Chris store service to the CUBE's compose. 

The service is not a full production service yet. This means that for instance DB migrations are  applied to the Chris store Django server in the CUBE's make file. That shouldn't be the case for a production service.

The required client libraries to communicate with the store are already available in CUBE (requests and collection-json). So everything is ready to start implementing the registration of plugins in CUBE by making http requests to the Chris store API from the manager script.