### PR TITLE
Add new key/value to 'target' spec

### DIFF
--- a/chris_backend/plugins/services/charm.py
+++ b/chris_backend/plugins/services/charm.py
@@ -895,7 +895,10 @@ class Charm():
                         "target": 
                         {
                             "image":            self.c_pluginInst.plugin.dock_image,
-                            "cmdParse":         True
+                            "cmdParse":         True,
+                            "selfexec":         self.c_pluginInst.plugin.selfexec,
+                            "selfpath":         self.c_pluginInst.plugin.selfpath,
+                            "execshell":        self.c_pluginInst.plugin.execshell
                         },
                         "manager":
                         {


### PR DESCRIPTION
 in JSON payload from charm --> pfcon --> pman.

This adds `selfexec`, `selfpath`, and `execshell` explicitly to the JSON payload in the `target` paragraph and as such eventually gets to `pman`. This provides values to `pman` that previously it had to collect by running the plugin image and parsing the returned JSON representation in the image.