### PR TITLE
Enable unauthenticated HTTP requests to the ChRIS store from CUBE to register plugins in CUBE.

### DIFF
--- a/chris_backend/plugins/services/manager.py
+++ b/chris_backend/plugins/services/manager.py
@@ -37,18 +37,18 @@ class PluginManager(object):
         parser_add = subparsers.add_parser('add', help='Add a new plugin')
         parser_add.add_argument('name', help="Plugin's name")
         parser_add.add_argument('computeresource',
-                                help="Compute resource where the plugin's instances runs")
+                                help="Compute resource where the plugin's instances run")
         parser_add.add_argument('storeurl',
                                 help="Url of ChRIS store where the plugin is registered")
-        parser_add.add_argument('storeusername', help="Username for the ChRIS store")
-        parser_add.add_argument('storepassword', help="Password for the ChRIS store")
+        parser_add.add_argument('--storeusername', help="Username for the ChRIS store")
+        parser_add.add_argument('--storepassword', help="Password for the ChRIS store")
         parser_add.add_argument('--storetimeout', help="ChRIS store request timeout")
 
         # create the parser for the "modify" command
         parser_modify = subparsers.add_parser('modify', help='Modify existing plugin')
         parser_modify.add_argument('name', help="Plugin's name")
         parser_modify.add_argument('--computeresource',
-                                help="Compute resource where the plugin's instances runs")
+                                help="Compute resource where the plugin's instances run")
         parser_modify.add_argument('--storeurl',
                                 help="Url of ChRIS store where the plugin is registered")
         parser_modify.add_argument('--storeusername', help="Username for the ChRIS store")
@@ -101,7 +101,7 @@ class PluginManager(object):
         if args.computeresource:
             (compute_resource, tf) = ComputeResource.objects.get_or_create(
                 compute_resource_identifier=args.computeresource)
-        if args.storeurl and args.storeusername and args.storepassword:
+        if args.storeurl:
             timeout = 30
             if args.storetimeout:
                 timeout = args.storetimeout
@@ -281,8 +281,8 @@ class PluginManager(object):
         return str_responseStatus
 
     @staticmethod
-    def get_plugin_representation_from_store(name, store_url, username, password,
-                                             timeout=30):
+    def get_plugin_representation_from_store(name, store_url, username=None,
+                                             password=None, timeout=30):
         """
         Get a plugin app representation from the ChRIS store.
         """

--- a/chris_backend/plugins/tests/test_manager.py
+++ b/chris_backend/plugins/tests/test_manager.py
@@ -69,12 +69,11 @@ class PluginManagerTests(TestCase):
         # mock manager's get_plugin_representation_from_store static method
         self.pl_manager.get_plugin_representation_from_store = mock.Mock(
             return_value=self.plugin_repr)
-        self.pl_manager.run(['add', 'testapp', 'host', 'http://localhost:8010/api/v1/',
-                             'cubeadmin', 'cubeadmin1234'])
+        self.pl_manager.run(['add', 'testapp', 'host', 'http://localhost:8010/api/v1/'])
         self.assertEquals(Plugin.objects.count(), 2)
         self.assertTrue(PluginParameter.objects.count() > 1)
         self.pl_manager.get_plugin_representation_from_store.assert_called_with(
-            'testapp', 'http://localhost:8010/api/v1/', 'cubeadmin', 'cubeadmin1234', 30)
+            'testapp', 'http://localhost:8010/api/v1/', None, None, 30)
 
     def test_mananger_can_modify_plugin(self):
         """
@@ -88,11 +87,9 @@ class PluginManagerTests(TestCase):
         self.pl_manager.get_plugin_representation_from_store = mock.Mock(
             return_value=self.plugin_repr)
         self.pl_manager.run(['modify', self.plugin_fs_name, '--computeresource', 'host1',
-                             '--storeurl', 'http://localhost:8010/api/v1/',
-                             '--storeusername', 'cubeadmin', '--storepassword',
-                             'cubeadmin1234'])
+                             '--storeurl', 'http://localhost:8010/api/v1/'])
         self.pl_manager.get_plugin_representation_from_store.assert_called_with(
-            'simplefsapp', 'http://localhost:8010/api/v1/', 'cubeadmin', 'cubeadmin1234', 30)
+            'simplefsapp', 'http://localhost:8010/api/v1/', None, None, 30)
 
         plugin = Plugin.objects.get(name=self.plugin_fs_name)
         self.assertTrue(plugin.modification_date > initial_modification_date)

--- a/docker-make-chris_dev.sh
+++ b/docker-make-chris_dev.sh
@@ -384,7 +384,7 @@ else
     for plugin in "${plugins[@]}"; do
         printf "${STEP}.$i:"
         printf "${LightBlue}[ ChRIS store ]${NC}::${Cyan}%-25s${NC} --> ${Yellow}[ CUBE ]${NC}::${Cyan}$COMPUTEENV${NC}..." "[ $plugin ]"
-        docker-compose exec chris_dev python plugins/services/manager.py add "${plugin}" $COMPUTEENV http://chrisstore:8010/api/v1/ cubeadmin cubeadmin1234
+        docker-compose exec chris_dev python plugins/services/manager.py add "${plugin}" $COMPUTEENV http://chrisstore:8010/api/v1/
         printf "\t${LightGreen}[ success ]${NC}\n"
         ((i++))
     done

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,6 +10,6 @@ pfmisc==1.2.2
 pytz==2016.7
 python-swiftclient==3.6.0
 django-storage-swift==1.2.19
-python-chrisstoreclient==0.0.5
+python-chrisstoreclient==0.0.6
 
 


### PR DESCRIPTION
CUBE is upgraded to use version 0.0.6 of the ChRIS store client which allows for unauthenticated GET requests to fetch a plugin's representation. Therefore the CUBE's manager can now add a new plugin without a ChRIS store's username and password. 