### PR TITLE
Remove legacy storage container.

### DIFF
--- a/docker-destroy-chris_dev.sh
+++ b/docker-destroy-chris_dev.sh
@@ -23,7 +23,6 @@ title -d 1 "Destroying persistent volumes..."
         "chris_dev_db_data"
         "chris_store_dev_db_data"
         "nd_swift_storage"
-        "pfcon_swift_storage"
     )
     a_PVOLS=()
     for vol in ${a_VOLS[@]}; do


### PR DESCRIPTION
docker-destroy tries to kill non-existent legacy container.