### PR TITLE
Fix unresponsiveness of Django server when the docker-make-chris_dev.…

### DIFF
--- a/chris_backend/config/settings/local.py
+++ b/chris_backend/config/settings/local.py
@@ -11,6 +11,7 @@ Local settings
 from .common import *  # noqa
 import os
 import logging
+import swiftclient
 
 
 # avoid cluttered console output (for instance logging all the http requests)
@@ -34,7 +35,14 @@ SWIFT_AUTH_URL = 'http://swift_service:8080/auth/v1.0'
 SWIFT_USERNAME = 'chris:chris1234'
 SWIFT_KEY = 'testing'
 SWIFT_CONTAINER_NAME = 'users'
-SWIFT_AUTO_CREATE_CONTAINER = True
+#SWIFT_AUTO_CREATE_CONTAINER = True
+# initiate a swift service connection and create 'users' container
+conn = swiftclient.Connection(
+    user=SWIFT_USERNAME,
+    key=SWIFT_KEY,
+    authurl=SWIFT_AUTH_URL,
+)
+conn.put_container(SWIFT_CONTAINER_NAME)
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
@@ -96,4 +104,3 @@ TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 # ------------------------------------------------------------------------------
 CORS_ORIGIN_ALLOW_ALL = True
 CORS_EXPOSE_HEADERS = ['Allow', 'Content-Type', 'Content-Length']
-

--- a/chris_backend/plugininstances/tests/test_manager.py
+++ b/chris_backend/plugininstances/tests/test_manager.py
@@ -6,9 +6,6 @@ from unittest import mock
 
 from django.test import TestCase, tag
 from django.contrib.auth.models import User
-from django.conf import settings
-
-import swiftclient
 
 from plugins.models import Plugin, PluginParameter
 from plugininstances.models import PluginInstance, ComputeResource
@@ -104,15 +101,6 @@ class PluginAppManagerTests(TestCase):
         #     if not os.path.exists(test_dir):
         #         os.makedirs(test_dir)
 
-        # initiate a Swift service connection and create container in case
-        # it doesn't already exist
-        conn = swiftclient.Connection(
-            user=settings.SWIFT_USERNAME,
-            key=settings.SWIFT_KEY,
-            authurl=settings.SWIFT_AUTH_URL,
-        )
-        conn.put_container(settings.SWIFT_CONTAINER_NAME)
-
         user = User.objects.get(username=self.username)
         plugin = Plugin.objects.get(name=self.plugin_fs_name)
         pl_inst = PluginInstance.objects.create(plugin=plugin, owner=user,
@@ -160,15 +148,6 @@ class PluginAppManagerTests(TestCase):
 
             This must be fixed in later versions!
         """
-        # initiate a Swift service connection and create container in case
-        # it doesn't already exist
-        conn = swiftclient.Connection(
-            user=settings.SWIFT_USERNAME,
-            key=settings.SWIFT_KEY,
-            authurl=settings.SWIFT_AUTH_URL,
-        )
-        conn.put_container(settings.SWIFT_CONTAINER_NAME)
-
         user = User.objects.get(username=self.username)
         plugin = Plugin.objects.get(name=self.plugin_fs_name)
         pl_inst = PluginInstance.objects.create(plugin=plugin, owner=user,

--- a/chris_backend/plugininstances/tests/test_views.py
+++ b/chris_backend/plugininstances/tests/test_views.py
@@ -537,9 +537,6 @@ class FileResourceViewTests(PluginInstanceFileViewTests):
             key=settings.SWIFT_KEY,
             authurl=settings.SWIFT_AUTH_URL,
         )
-        # create container in case it doesn't already exist
-        conn.put_container(settings.SWIFT_CONTAINER_NAME)
-
         # upload file to Swift storage
         with io.StringIO("test file") as file1:
             conn.put_object(settings.SWIFT_CONTAINER_NAME, '/tests/file1.txt',

--- a/chris_backend/uploadedfiles/tests/test_views.py
+++ b/chris_backend/uploadedfiles/tests/test_views.py
@@ -185,8 +185,6 @@ class UploadedFileResourceViewTests(UploadedFileViewTests):
             key=settings.SWIFT_KEY,
             authurl=settings.SWIFT_AUTH_URL,
         )
-        # create container in case it doesn't already exist
-        conn.put_container(settings.SWIFT_CONTAINER_NAME)
 
         # upload file to Swift storage
         with io.StringIO("test file") as file1:

--- a/docker-make-chris_dev.sh
+++ b/docker-make-chris_dev.sh
@@ -421,5 +421,10 @@ else
         docker-compose run --service-ports chris_dev
         echo ""
         windowBottom
+    else
+        title -d 1 "Restarting CUBE's Django development server in non-interactive mode..."
+        docker-compose restart chris_dev
+        echo ""
+        windowBottom
     fi
 fi


### PR DESCRIPTION
…sh script is run with -i flag.

Fix unresponsiveness of Django server whenthe docker-make-chris_dev.sh script is run with -i flag

Fix bug in which the raw value for a plugin parameter from a request was being passed to the plugin instance manager. Instead the serializer validated value is now passed.

Remove swift container creation code from tests and add it to the Django settings