### PR TITLE
Remove unnecesary code in IsRelatedFeedOwnerOrChris and improve IsRel…

### DIFF
--- a/chris_backend/feeds/permissions.py
+++ b/chris_backend/feeds/permissions.py
@@ -1,3 +1,4 @@
+
 from rest_framework import permissions
 
 
@@ -35,30 +36,22 @@ class IsOwnerOrChrisOrReadOnly(permissions.BasePermission):
 
 class IsRelatedFeedOwnerOrChris(permissions.BasePermission):
     """
-    Custom permission to only allow owners of an object or superuser
-    'chris' to modify/edit a feed-related object (eg. a note).
+    Custom permission to only allow owners of a feed associated to an object or superuser
+    'chris' to modify/edit the object (eg. a note).
     """
 
     def has_object_permission(self, request, view, obj):
         # Read and write permissions are only allowed to
         # the owner and superuser 'chris'.
-        #import pdb; pdb.set_trace()
         if request.user.username == 'chris':
             return True
-        if hasattr(obj.feed, 'all'):
-            owner_lists = [feed.owner.all() for feed in obj.feed.all()]
-            for owner_list in owner_lists:
-                if request.user in owner_list:
-                    return True
-        elif request.user in obj.feed.owner.all():
-            return True
-        return False
+        return request.user in obj.feed.owner.all()
 
 
 class IsRelatedTagOwnerOrChris(permissions.BasePermission):
     """
-    Custom permission to only allow owners of a related tag or superuser
-    'chris' to access an object (eg. a tagging).
+    Custom permission to only allow the owner of a tag associated to an object or
+    superuser 'chris' to access the object (eg. a tagging).
     """
 
     def has_object_permission(self, request, view, obj):
@@ -67,8 +60,3 @@ class IsRelatedTagOwnerOrChris(permissions.BasePermission):
         if (request.user.username == 'chris') or (request.user == obj.tag.owner):
             return True
         return False
-
-
-
-
-

--- a/chris_backend/feeds/tests/test_models.py
+++ b/chris_backend/feeds/tests/test_models.py
@@ -51,7 +51,20 @@ class FeedModelTests(TestCase):
         # create a plugin instance that in turn creates a new feed
         user = User.objects.get(username=self.username)
         plugin = Plugin.objects.get(name=self.plugin_name)
-        pl_inst = PluginInstance.objects.create(plugin=plugin, owner=user, 
+        pl_inst = PluginInstance.objects.create(plugin=plugin, owner=user,
                                             compute_resource=plugin.compute_resource)
         pl_inst.feed.name = self.feed_name
         self.assertEqual(Note.objects.count(), 1)
+
+    def test_get_creator(self):
+        """
+        Test whether custom get_creator method properly return the user that created the
+        feed.
+        """
+        # create a plugin instance that in turn creates a new feed
+        user = User.objects.get(username=self.username)
+        plugin = Plugin.objects.get(name=self.plugin_name)
+        pl_inst = PluginInstance.objects.create(plugin=plugin, owner=user,
+                                            compute_resource=plugin.compute_resource)
+        feed_creator = pl_inst.feed.get_creator()
+        self.assertEqual(feed_creator, user)

--- a/chris_backend/pipelineinstances/serializers.py
+++ b/chris_backend/pipelineinstances/serializers.py
@@ -71,12 +71,13 @@ class PipelineInstanceSerializer(serializers.HyperlinkedModelSerializer):
         parsed_params_dict = {}
         for param in request_data:
             try:
-                id_list = param.split('_')[:3]
+                param_elements = param.split('_')
+                id_list = param_elements[:3]
                 piping_id = int(id_list[1])
             except Exception:
                 pass
             else:
-                param_name = '_'.join(id_list[3:])
+                param_name = '_'.join(param_elements[3:])
                 if piping_id in parsed_params_dict:
                     parsed_params_dict[piping_id][param_name] = request_data[param]
                 else:

--- a/chris_backend/pipelineinstances/tests/test_serializers.py
+++ b/chris_backend/pipelineinstances/tests/test_serializers.py
@@ -1,0 +1,147 @@
+
+import logging
+from unittest import mock
+
+from django.test import TestCase
+from django.contrib.auth.models import User
+
+from rest_framework import serializers
+
+from plugininstances.models import PluginInstance
+from plugins.models import Plugin
+from plugins.models import ComputeResource
+from plugins.models import PluginParameter, DefaultPathParameter, DefaultIntParameter
+from pipelines.models import Pipeline, PluginPiping
+from pipelineinstances.models import PipelineInstance
+from pipelineinstances.serializers import PipelineInstanceSerializer
+
+
+class SerializerTests(TestCase):
+
+    def setUp(self):
+        # avoid cluttered console output (for instance logging all the http requests)
+        logging.disable(logging.CRITICAL)
+
+        self.plugin_fs_name = "simplefsapp"
+        self.plugin_fs_parameters = {'dir': {'type': 'path', 'optional': True,
+                                             'default': "./"}}
+        self.plugin_ds_name = "simpledsapp"
+        self.plugin_ds_parameters = {'dummyInt': {'type': 'integer', 'optional': True,
+                                                  'default': 111111}}
+        self.username = 'foo'
+        self.password = 'foo-pass'
+        (self.compute_resource, tf) = ComputeResource.objects.get_or_create(
+            compute_resource_identifier="host")
+
+        # create plugins
+        (plugin_fs, tf) = Plugin.objects.get_or_create(name=self.plugin_fs_name,
+                                                       type='fs',
+                                                       compute_resource=self.compute_resource)
+        (plugin_ds, tf) = Plugin.objects.get_or_create(name=self.plugin_ds_name,
+                                                       type='ds',
+                                                       compute_resource=self.compute_resource)
+        # add plugins' parameters
+        (plg_param_fs, tf) = PluginParameter.objects.get_or_create(
+            plugin=plugin_fs,
+            name='dir',
+            type=self.plugin_fs_parameters['dir']['type'],
+            optional=self.plugin_fs_parameters['dir']['optional'])
+        default = self.plugin_fs_parameters['dir']['default']
+        DefaultPathParameter.objects.get_or_create(plugin_param=plg_param_fs,
+                                                   value=default)  # set plugin parameter default
+
+        # add a parameter with a default
+        (plg_param_ds, tf)= PluginParameter.objects.get_or_create(
+            plugin=plugin_ds,
+            name='dummyInt',
+            type=self.plugin_ds_parameters['dummyInt']['type'],
+            optional=self.plugin_ds_parameters['dummyInt']['optional']
+        )
+        default = self.plugin_ds_parameters['dummyInt']['default']
+        DefaultIntParameter.objects.get_or_create(plugin_param=plg_param_ds,
+                                                  value=default)  # set plugin parameter default
+
+        # create user
+        user = User.objects.create_user(username=self.username, password=self.password)
+
+        # create a pipeline
+        self.pipeline_name = 'Pipeline1'
+        (pipeline, tf) = Pipeline.objects.get_or_create(name=self.pipeline_name,
+                                                        owner=user, category='test')
+
+        # create two plugin pipings
+        self.pips = []
+        (pip, tf) = PluginPiping.objects.get_or_create(plugin=plugin_ds,
+                                                       pipeline=pipeline)
+        self.pips.append(pip)
+        (pip, tf) = PluginPiping.objects.get_or_create(plugin=plugin_ds, previous=pip,
+                                                       pipeline=pipeline)
+        self.pips.append(pip)
+
+    def tearDown(self):
+        # re-enable logging
+        logging.disable(logging.DEBUG)
+
+
+class PipelineInstanceSerializerTests(SerializerTests):
+
+    def setUp(self):
+        super(PipelineInstanceSerializerTests, self).setUp()
+
+    def test_create(self):
+        """
+        Test whether overriden 'create' method successfully creates a new pipeline
+        instance after deleting 'previous_plugin_inst_id' from serializer data as it's
+        not a model field.
+        """
+        owner = User.objects.get(username=self.username)
+        plugin = Plugin.objects.get(name=self.plugin_fs_name)
+        (pl_inst, tf) = PluginInstance.objects.get_or_create(plugin=plugin, owner=owner,
+                                            compute_resource=plugin.compute_resource)
+        pipeline = Pipeline.objects.get(name=self.pipeline_name)
+        data = {'title': 'PipelineInst1', 'previous_plugin_inst_id': pl_inst.id}
+        pipeline_inst_serializer = PipelineInstanceSerializer(data=data)
+        pipeline_inst_serializer.is_valid(raise_exception=True)
+        pipeline_inst_serializer.validated_data['pipeline'] = pipeline
+        pipeline_inst = pipeline_inst_serializer.create(pipeline_inst_serializer.validated_data)
+        self.assertNotIn('previous_plugin_inst_id', pipeline_inst_serializer.validated_data)
+        self.assertIsInstance(pipeline_inst, PipelineInstance)
+
+    def test_validate_previous_plugin_inst(self):
+        """
+        Test whether custom validate_previous_plugin_inst method validates that an integer
+        id is provided for previous instance. Then checks that the id exists in the DB and
+        that the user can run plugins within the corresponding feed.
+        """
+        owner = User.objects.get(username=self.username)
+        plugin = Plugin.objects.get(name=self.plugin_fs_name)
+        (pl_inst, tf) = PluginInstance.objects.get_or_create(plugin=plugin, owner=owner,
+                                            compute_resource=plugin.compute_resource)
+        data = {'title': 'PipelineInst1', 'previous_plugin_inst_id': pl_inst.id}
+        pipeline_inst_serializer = PipelineInstanceSerializer(data=data)
+        pipeline_inst_serializer.context['request'] = mock.Mock()
+        pipeline_inst_serializer.context['request'].user = owner
+        with self.assertRaises(serializers.ValidationError):
+            pipeline_inst_serializer.validate_previous_plugin_inst(None)
+        with self.assertRaises(serializers.ValidationError):
+            pipeline_inst_serializer.validate_previous_plugin_inst(pl_inst.id+1)
+        # create another user
+        another_user = User.objects.create_user(username='boo', password='far')
+        with self.assertRaises(serializers.ValidationError):
+            pipeline_inst_serializer.context['request'].user = another_user
+            pipeline_inst_serializer.validate_previous_plugin_inst(pl_inst.id)
+
+    def test_parse_parameters(self):
+        """
+        Test whether custom parse_parameters method properly parses the pipeline instance
+        parameters in the request data dictionary.
+        """
+        plugin = Plugin.objects.get(name=self.plugin_ds_name)
+        pipeline_inst_serializer = PipelineInstanceSerializer()
+        pipeline_inst_serializer.context['request'] = mock.Mock()
+        # parameters name in the request have the form
+        # < plugin.id > _ < piping.id > _ < previous_piping.id > _ < param.name >
+        param_name = "%s_%s_%s_%s" % (plugin.id, self.pips[1].id, self.pips[0].id, 'dummy_Int')
+        pipeline_inst_serializer.context['request'].data = {param_name: 1122}
+        parsed_params_dict = pipeline_inst_serializer.parse_parameters()
+        self.assertEqual(parsed_params_dict, {self.pips[1].id: {'dummy_Int': 1122}})

--- a/chris_backend/pipelineinstances/tests/test_views.py
+++ b/chris_backend/pipelineinstances/tests/test_views.py
@@ -1,0 +1,222 @@
+
+import logging
+import json
+from unittest import mock
+
+from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth.models import User
+
+from rest_framework import status
+
+from plugins.models import Plugin
+from plugins.models import ComputeResource
+from plugins.models import PluginParameter, DefaultPathParameter, DefaultIntParameter
+from plugininstances.models import PluginInstance
+from pipelines.models import Pipeline, PluginPiping
+from pipelineinstances.models import PipelineInstance
+from pipelineinstances import views
+
+
+class ViewTests(TestCase):
+    
+    def setUp(self):
+        # avoid cluttered console output (for instance logging all the http requests)
+        logging.disable(logging.CRITICAL)
+
+        self.content_type = 'application/vnd.collection+json'
+
+        self.plugin_fs_name = "simplefsapp"
+        self.plugin_fs_parameters = {'dir': {'type': 'path', 'optional': True,
+                                             'default': "./"}}
+        self.plugin_ds_name = "simpledsapp"
+        self.plugin_ds_parameters = {'dummyInt': {'type': 'integer', 'optional': True,
+                                                  'default': 111111}}
+        self.username = 'foo'
+        self.password = 'foo-pass'
+        (self.compute_resource, tf) = ComputeResource.objects.get_or_create(
+            compute_resource_identifier="host")
+
+        # create plugins
+        (plugin_fs, tf) = Plugin.objects.get_or_create(name=self.plugin_fs_name,
+                                                       type='fs',
+                                                       compute_resource=self.compute_resource)
+        (plugin_ds, tf) = Plugin.objects.get_or_create(name=self.plugin_ds_name,
+                                                       type='ds',
+                                                       compute_resource=self.compute_resource)
+        # add plugins' parameters
+        (plg_param_fs, tf) = PluginParameter.objects.get_or_create(
+            plugin=plugin_fs,
+            name='dir',
+            type=self.plugin_fs_parameters['dir']['type'],
+            optional=self.plugin_fs_parameters['dir']['optional'])
+        default = self.plugin_fs_parameters['dir']['default']
+        DefaultPathParameter.objects.get_or_create(plugin_param=plg_param_fs,
+                                                   value=default)  # set plugin parameter default
+
+        # add a parameter with a default
+        (plg_param_ds, tf)= PluginParameter.objects.get_or_create(
+            plugin=plugin_ds,
+            name='dummyInt',
+            type=self.plugin_ds_parameters['dummyInt']['type'],
+            optional=self.plugin_ds_parameters['dummyInt']['optional']
+        )
+        default = self.plugin_ds_parameters['dummyInt']['default']
+        DefaultIntParameter.objects.get_or_create(plugin_param=plg_param_ds,
+                                                  value=default)  # set plugin parameter default
+
+        # create user
+        user = User.objects.create_user(username=self.username, password=self.password)
+
+        # create a pipeline
+        self.pipeline_name = 'Pipeline1'
+        (pipeline, tf) = Pipeline.objects.get_or_create(name=self.pipeline_name,
+                                                        owner=user, category='test')
+
+        # create two plugin pipings
+        self.pips = []
+        (pip, tf) = PluginPiping.objects.get_or_create(plugin=plugin_ds,
+                                                       pipeline=pipeline)
+        self.pips.append(pip)
+        (pip, tf) = PluginPiping.objects.get_or_create(plugin=plugin_ds, previous=pip,
+                                                       pipeline=pipeline)
+        self.pips.append(pip)
+
+        # create another user
+        self.other_username = 'boo'
+        self.other_password = 'far'
+        User.objects.create_user(username=self.other_username, password=self.other_password)
+
+    def tearDown(self):
+        # re-enable logging
+        logging.disable(logging.DEBUG)
+
+
+class PipelineInstanceListViewTests(ViewTests):
+    """
+    Test the pipelineinstance-list view.
+    """
+
+    def setUp(self):
+        super(PipelineInstanceListViewTests, self).setUp()
+        pipeline = Pipeline.objects.get(name=self.pipeline_name)
+        self.create_read_url = reverse("pipelineinstance-list", kwargs={"pk": pipeline.id})
+        owner = User.objects.get(username=self.username)
+        plugin_fs = Plugin.objects.get(name=self.plugin_fs_name)
+        (self.pl_inst, tf) = PluginInstance.objects.get_or_create(plugin=plugin_fs, owner=owner,
+                                            compute_resource=plugin_fs.compute_resource)
+
+    def test_pipeline_instance_create_success(self):
+
+        plugin_ds = Plugin.objects.get(name=self.plugin_ds_name)
+        param_name = "%s_%s_%s_%s" % (plugin_ds.id, self.pips[1].id, self.pips[0].id, 'dummyInt')
+        post = json.dumps(
+            {"template": {"data": [{"name": "title", "value": "PipelineInst1"},
+                                   {"name": "previous_plugin_inst_id", "value": self.pl_inst.id},
+                                   {"name": param_name, "value": 333333}]}})
+        # make API request
+        self.client.login(username=self.username, password=self.password)
+        response = self.client.post(self.create_read_url, data=post, content_type=self.content_type)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_pipeline_instance_list_success(self):
+        pipeline = Pipeline.objects.get(name=self.pipeline_name)
+        PipelineInstance.objects.get_or_create(title="PipelineInst1", pipeline=pipeline)
+        self.client.login(username=self.username, password=self.password)
+        response = self.client.get(self.create_read_url)
+        self.assertContains(response, "PipelineInst1")
+
+    def test_pipeline_instance_list_failure_unauthenticated(self):
+        response = self.client.get(self.create_read_url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
+class PipelineInstanceListQuerySearchViewTests(ViewTests):
+    """
+    Test the pipelineinstance-list-query-search view.
+    """
+
+    def setUp(self):
+        super(PipelineInstanceListQuerySearchViewTests, self).setUp()
+
+        self.query_url1 = reverse("pipelineinstance-list-query-search") + "?title=PipelineInst"
+        self.query_url2 = reverse("pipelineinstance-list-query-search") + "?pipeline_name=" + \
+                          self.pipeline_name
+
+    def test_pipeline_instance_query_search_list_success(self):
+        pipeline = Pipeline.objects.get(name=self.pipeline_name)
+        PipelineInstance.objects.get_or_create(title="PipelineInst1", pipeline=pipeline)
+        PipelineInstance.objects.get_or_create(title="PipelineMyInst", pipeline=pipeline)
+        self.client.login(username=self.username, password=self.password)
+        response = self.client.get(self.query_url1)
+        # response should only contain the instances that match the query
+        self.assertContains(response, "PipelineInst1")
+        self.assertNotContains(response, "PipelineMyInst")
+        response = self.client.get(self.query_url2)
+        self.assertContains(response, "PipelineInst1")
+        self.assertContains(response, "PipelineMyInst")
+
+    def test_plugin_instance_query_search_list_failure_unauthenticated(self):
+        response = self.client.get(self.query_url1)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
+class PipelineInstanceDetailViewTests(ViewTests):
+    """
+    Test the pipelineinstance-detail view.
+    """
+
+    def setUp(self):
+        super(PipelineInstanceDetailViewTests, self).setUp()
+        pipeline = Pipeline.objects.get(name=self.pipeline_name)
+        (pipeline_inst, tf) = PipelineInstance.objects.get_or_create(title="PipelineInst1",
+                                                                     pipeline=pipeline)
+        self.read_url = reverse("pipelineinstance-detail", kwargs={"pk": pipeline_inst.id})
+
+    def test_pipeline_instance_detail_success(self):
+        self.client.login(username=self.username, password=self.password)
+        response = self.client.get(self.read_url)
+        self.assertContains(response, "PipelineInst1")
+
+    def test_pipeline_instance_detail_failure_unauthenticated(self):
+        response = self.client.get(self.read_url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
+class PipelineInstancePluginInstanceListViewTests(ViewTests):
+    """
+    Test the pipelineinstance-plugininstance-list view.
+    """
+
+    def setUp(self):
+        super(PipelineInstancePluginInstanceListViewTests, self).setUp()
+        pipeline = Pipeline.objects.get(name=self.pipeline_name)
+        (self.pipeline_inst, tf) = PipelineInstance.objects.get_or_create(title="PipelineInst1",
+                                                                     pipeline=pipeline)
+        self.list_url = reverse("pipelineinstance-plugininstance-list",
+                                kwargs={"pk": self.pipeline_inst.id})
+
+    def test_pipeline_instance_plugin_instance_list_success(self):
+        plugin_fs = Plugin.objects.get(name=self.plugin_fs_name)
+        owner = User.objects.get(username=self.username)
+        (previous_plg_inst, tf) = PluginInstance.objects.get_or_create(plugin=plugin_fs,
+                                                                  owner=owner,
+                                            compute_resource=plugin_fs.compute_resource)
+        pipeline = Pipeline.objects.get(name=self.pipeline_name)
+        for pip in pipeline.plugin_pipings.all():
+            plugin_ds = pip.plugin
+            (pl_inst_ds, tf) = PluginInstance.objects.get_or_create(plugin=plugin_ds,
+                                                                    title="PluginInst" + str(pip.id),
+                                                                  owner=owner,
+                                                        pipeline_inst=self.pipeline_inst,
+                                                            previous=previous_plg_inst,
+                                            compute_resource=plugin_fs.compute_resource)
+            previous_plg_inst = pl_inst_ds
+        self.client.login(username=self.username, password=self.password)
+        response = self.client.get(self.list_url)
+        for pip in pipeline.plugin_pipings.all():
+            self.assertContains(response, "PluginInst" + str(pip.id))
+
+    def test_pipeline_instance_plugin_instance_list_failure_unauthenticated(self):
+        response = self.client.get(self.list_url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/chris_backend/pipelines/models.py
+++ b/chris_backend/pipelines/models.py
@@ -27,9 +27,9 @@ class Pipeline(models.Model):
 
     def get_pipings_parameters_names(self):
         """
-        Custom method to get the list of all associated plugin pipings. The name of the
-        parameters is transformed to have the plugin id, piping id and previous piping
-        id as a prefix.
+        Custom method to get the list of all the plugin parameter names for all the
+        associated plugin pipings. The name of the parameters is transformed to have the
+        plugin id, piping id and previous piping id as a prefix.
         """
         pipings = self.plugin_pipings.all()
         param_names = []
@@ -63,13 +63,13 @@ class Pipeline(models.Model):
                     tree[prev_id] = {'piping': pip.previous, 'child_ids': [pip.id]}
         return {'root_id': root_id, 'tree': tree}
 
-    def checkParameterDefaultValues(self):
+    def check_parameter_default_values(self):
         """
         Custom method to raise an exception if any of the plugin parameters associated to
         any of the pipings in the pipeline doesn't have a default value.
         """
         for piping in self.plugin_pipings.all():
-            piping.checkParameterDefaultValues()
+            piping.check_parameter_default_values()
 
     @staticmethod
     def get_accesible_pipelines(user):
@@ -132,10 +132,10 @@ class PluginPiping(models.Model):
             default_piping_param.plugin_param = parameter
             default = parameter.get_default()
             # use plugin's parameter default for piping's default
-            default_piping_param.value = default
+            default_piping_param.value = default.value if default else None
             default_piping_param.save()
 
-    def checkParameterDefaultValues(self):
+    def check_parameter_default_values(self):
         """
         Custom method to raise an exception if any of the plugin parameters associated to
         the piping doesn't have a default value.

--- a/chris_backend/pipelines/serializers.py
+++ b/chris_backend/pipelines/serializers.py
@@ -151,7 +151,7 @@ class PipelineSerializer(serializers.HyperlinkedModelSerializer):
                     'default values'
         if not locked and self.instance:
             try:
-                self.instance.checkParameterDefaultValues()
+                self.instance.check_parameter_default_values()
             except ValueError:
                 raise serializers.ValidationError(error_msg)
         return locked

--- a/chris_backend/pipelines/tests/test_models.py
+++ b/chris_backend/pipelines/tests/test_models.py
@@ -1,0 +1,169 @@
+
+import logging
+
+from django.test import TestCase
+from django.contrib.auth.models import User
+
+from plugins.models import Plugin
+from plugins.models import ComputeResource
+from plugins.models import PluginParameter, DefaultPathParameter, DefaultIntParameter
+from pipelines.models import Pipeline
+from pipelines.models import PluginPiping
+from pipelines.models import DEFAULT_PIPING_PARAMETER_MODELS
+
+
+class ModelTests(TestCase):
+
+    def setUp(self):
+        # avoid cluttered console output (for instance logging all the http requests)
+        logging.disable(logging.CRITICAL)
+
+        self.plugin_ds_name = "simpledsapp"
+        self.plugin_ds_parameters = {'prefix': {'type': 'string', 'optional': False}}
+        self.username = 'foo'
+        self.password = 'foo-pass'
+        (self.compute_resource, tf) = ComputeResource.objects.get_or_create(
+            compute_resource_identifier="host")
+
+        # create plugin
+        (plugin_ds, tf) = Plugin.objects.get_or_create(name=self.plugin_ds_name,
+                                                       type='ds',
+                                                       compute_resource=self.compute_resource)
+        # add plugin's parameters
+        (plg_param_ds, tf)= PluginParameter.objects.get_or_create(
+            plugin=plugin_ds,
+            name='prefix',
+            type=self.plugin_ds_parameters['prefix']['type'],
+            optional=self.plugin_ds_parameters['prefix']['optional']) # this plugin parameter has no default
+
+        # create user
+        user = User.objects.create_user(username=self.username, password=self.password)
+
+        # create a pipeline
+        self.pipeline_name = 'Pipeline1'
+        (pipeline, tf) = Pipeline.objects.get_or_create(name=self.pipeline_name, owner=user)
+
+        # create two plugin pipings
+        self.pips = []
+        (pip, tf) = PluginPiping.objects.get_or_create(plugin=plugin_ds, pipeline=pipeline)
+        self.pips.append(pip)
+        (pip, tf) = PluginPiping.objects.get_or_create(plugin=plugin_ds, previous=pip,
+                                                        pipeline=pipeline)
+        self.pips.append(pip)
+
+        # create default values for the piping parameters as the corresponding plugin
+        # didn't set a default
+        param_type = self.plugin_ds_parameters['prefix']['type']
+        for i in range(2):
+            default_piping_param = DEFAULT_PIPING_PARAMETER_MODELS[param_type]()
+            default_piping_param.plugin_piping = self.pips[i]
+            default_piping_param.plugin_param = plg_param_ds
+            default_piping_param.value = "test" + str(i)
+            default_piping_param.save()
+
+    def tearDown(self):
+        # re-enable logging
+        logging.disable(logging.DEBUG)
+
+
+class PipelineModelTests(ModelTests):
+
+    def test_get_pipings_parameters_names(self):
+        """
+        Test whether custom get_pipings_parameters_names method returns the list of all
+        the plugin parameter names for all the associated plugin pipings. The name of the
+        parameters should be transformed to have the plugin id, piping id and previous
+        piping id as a prefix.
+        """
+        plugin_ds = Plugin.objects.get(name=self.plugin_ds_name)
+        param = plugin_ds.parameters.get(name='prefix')
+        pipeline = Pipeline.objects.get(name=self.pipeline_name)
+        param_names = pipeline.get_pipings_parameters_names()
+        self.assertEqual(len(param_names), 2)
+        self.assertEqual(param_names[0], "%s_%s_%s_%s" %
+                         (plugin_ds.id, self.pips[0].id, "null", param.name))
+        self.assertEqual(param_names[1], "%s_%s_%s_%s" %
+                         (plugin_ds.id, self.pips[1].id, self.pips[0].id, param.name))
+
+    def test_get_pipings_tree(self):
+        """
+        Test whether custom get_pipings_tree method returns a dictionary containing a
+        dictionary representing a tree of pipings and the id of the piping that is the
+        root of the tree. The keys of the dictionary tree should be the pipings' ids and
+        the values the dictionaries containing the piping and the list of child pipings' ids.
+        """
+        pipeline = Pipeline.objects.get(name=self.pipeline_name)
+        tree_dict = pipeline.get_pipings_tree()
+        root_id = tree_dict['root_id']
+        tree = tree_dict['tree']
+        self.assertEqual(root_id, self.pips[0].id)
+        self.assertEqual(tree[root_id], {'piping': self.pips[0], 'child_ids': [self.pips[1].id]})
+
+    def test_check_parameter_default_values(self):
+        """
+        Test whether custom check_parameter_default_values method raises an exception if
+        any of the plugin parameters associated to any of the pipings in the pipeline
+        doesn't have a default value.
+        """
+        pipeline = Pipeline.objects.get(name=self.pipeline_name)
+        plugin_ds = Plugin.objects.get(name=self.plugin_ds_name)
+        # add a new plugin piping to pipeline but do not set a default value for
+        # the plugin parameter
+        PluginPiping.objects.get_or_create(plugin=plugin_ds, pipeline=pipeline,
+                                           previous=self.pips[1])
+        with self.assertRaises(ValueError):
+            pipeline.check_parameter_default_values()
+
+    def test_get_accesible_pipelines(self):
+        """
+        Test whether custom get_accesible_pipelines method returns a filtered queryset
+        with all the pipelines that are accessible to a given user (not locked or
+        otherwise own by the user).
+        """
+        user1 = User.objects.get(username=self.username)
+        # create new user
+        user2 = User.objects.create_user(username='testuser', password='testuser-pass')
+        accessible_pipelines_user1 = Pipeline.get_accesible_pipelines(user1)
+        self.assertEqual(len(accessible_pipelines_user1),1)
+        self.assertEqual(accessible_pipelines_user1[0], Pipeline.objects.all()[0])
+        self.assertEqual(len(Pipeline.get_accesible_pipelines(user2)), 0)
+
+
+class PluginPipingModelTests(ModelTests):
+
+    def test_save(self):
+        """
+        Test whether overriden save method saves the default plugin parameters' values
+        associated with this piping.
+        """
+        plugin_ds = Plugin.objects.get(name=self.plugin_ds_name)
+        # add a parameter with a default
+        (plg_param_ds, tf)= PluginParameter.objects.get_or_create(
+            plugin=plugin_ds,
+            name='dummyInt',
+            type='integer',
+            optional=True
+        )
+        DefaultIntParameter.objects.get_or_create(plugin_param=plg_param_ds, value=1)  # set plugin parameter default
+        pipeline = Pipeline.objects.get(name=self.pipeline_name)
+        pip = PluginPiping()
+        pip.plugin = plugin_ds
+        pip.pipeline = pipeline
+        pip.save()
+        defaults = pip.integer_param.all()
+        self.assertEqual(len(defaults), 1)
+        self.assertEqual(defaults[0].value, 1)
+
+    def test_check_parameter_default_values(self):
+        """
+        Test whether custom check_parameter_default_values method raises an exception if
+        any of the plugin parameters associated to the piping doesn't have a default value.
+        """
+        pipeline = Pipeline.objects.get(name=self.pipeline_name)
+        plugin_ds = Plugin.objects.get(name=self.plugin_ds_name)
+        # add a new plugin piping to pipeline but do not set a default value for
+        # the plugin parameter
+        (pip, tf) = PluginPiping.objects.get_or_create(plugin=plugin_ds, pipeline=pipeline,
+                                           previous=self.pips[1])
+        with self.assertRaises(ValueError):
+            pip.check_parameter_default_values()

--- a/chris_backend/plugininstances/services/manager.py
+++ b/chris_backend/plugininstances/services/manager.py
@@ -3,8 +3,6 @@ Plugin app manager module that provides functionality to run and check the execu
 status of a plugin app.
 """
 
-import time
-
 from django.conf import settings
 
 from .charm import Charm
@@ -99,27 +97,6 @@ class PluginAppManager(object):
         # registration occurs via a call to the overloaded retrieve() method in PluginInstanceDetail in
         # plugins/views.py.
         #
-
-    @staticmethod
-    def check_apps_exec_server(**kwargs):
-        """
-        Check if a remote server instance is servicing requests.
-        """
-        # pudb.set_trace()
-        chris_service = Charm(**kwargs)
-        chris_service.app_service_checkIfAvailable(**kwargs)
-        # Wait a bit for transients
-        time.sleep(5)
-
-    @staticmethod
-    def shutdown_apps_exec_server(**kwargs):
-        """
-        Shutdown a remote server instance.
-        """
-        chris_service = Charm(**kwargs)
-        chris_service.app_service_shutdown(**kwargs)
-        # Wait a bit for transients
-        time.sleep(5)
 
     @staticmethod
     def check_plugin_app_exec_status(plugin_inst):

--- a/chris_backend/plugininstances/tests/test_manager.py
+++ b/chris_backend/plugininstances/tests/test_manager.py
@@ -7,7 +7,8 @@ from unittest import mock
 from django.test import TestCase, tag
 from django.contrib.auth.models import User
 
-from plugins.models import Plugin, PluginParameter
+from plugins.models import Plugin
+from plugins.models import PluginParameter, DefaultPathParameter
 from plugininstances.models import PluginInstance, ComputeResource
 from plugininstances.services import manager
 
@@ -46,11 +47,15 @@ class PluginAppManagerTests(TestCase):
         (plugin_fs, tf) = Plugin.objects.get_or_create(**data)
 
         # add plugin's parameters
-        PluginParameter.objects.get_or_create(
+        (plg_param, tf) = PluginParameter.objects.get_or_create(
             plugin=plugin_fs,
             name=parameters[0]['name'],
             type=parameters[0]['type'],
-            flag=parameters[0]['flag'])
+            flag=parameters[0]['flag'],
+            optional=parameters[0]['optional'],
+        )
+        default = parameters[0]['default']
+        DefaultPathParameter.objects.get_or_create(plugin_param=plg_param, value=default)
 
         # create user
         User.objects.create_user(username=self.username, password=self.password)

--- a/chris_backend/plugins/models.py
+++ b/chris_backend/plugins/models.py
@@ -116,11 +116,10 @@ class PluginParameter(models.Model):
 
     def get_default(self):
         """
-        Overriden to get the default parameter value regardless of type.
+        Overriden to get the default parameter instance regardless of its type.
         """
         default_attr_name = '%s_default' % self.type
-        default = getattr(self, default_attr_name, None)
-        return default.value if default else None
+        return getattr(self, default_attr_name, None)
 
 
 class DefaultStrParameter(models.Model):

--- a/chris_backend/plugins/serializers.py
+++ b/chris_backend/plugins/serializers.py
@@ -162,7 +162,8 @@ class PluginParameterSerializer(serializers.HyperlinkedModelSerializer):
         """
         Overriden to get the default parameter value regardless of type.
         """
-        return obj.get_default()
+        default = obj.get_default()
+        return default.value if default else None
 
 
 class DefaultStrParameterSerializer(serializers.HyperlinkedModelSerializer):

--- a/chris_backend/plugins/services/manager.py
+++ b/chris_backend/plugins/services/manager.py
@@ -57,12 +57,6 @@ class PluginManager(object):
         parser_remove.add_argument('name', help="Plugin's name")
 
         self.parser = parser
-        self.str_service        = ''
-
-        # Debug specifications
-        self.b_quiet            = False
-        self.b_useDebug         = True
-        self.str_debugFile      = '%s/tmp/debug-charm.log' % os.environ['HOME']
 
     def add_plugin(self, args):
         """

--- a/chris_backend/plugins/tests/test_manager.py
+++ b/chris_backend/plugins/tests/test_manager.py
@@ -5,7 +5,9 @@ from unittest import mock
 
 from django.test import TestCase
 
-from plugins.models import Plugin, PluginParameter, ComputeResource
+from plugins.models import Plugin
+from plugins.models import PluginParameter, DefaultPathParameter
+from plugins.models import ComputeResource
 from plugins.services import manager
 
 
@@ -42,11 +44,15 @@ class PluginManagerTests(TestCase):
         (plugin_fs, tf) = Plugin.objects.get_or_create(**data)
 
         # add plugin's parameters
-        PluginParameter.objects.get_or_create(
+        (plg_param, tf) = PluginParameter.objects.get_or_create(
             plugin=plugin_fs,
             name=parameters[0]['name'],
             type=parameters[0]['type'],
-            flag=parameters[0]['flag'])
+            flag=parameters[0]['flag'],
+            optional=parameters[0]['optional']
+        )
+        default = parameters[0]['default']
+        DefaultPathParameter.objects.get_or_create(plugin_param=plg_param, value=default)
 
     def tearDown(self):
         # re-enable logging

--- a/chris_backend/plugins/tests/test_models.py
+++ b/chris_backend/plugins/tests/test_models.py
@@ -3,18 +3,20 @@ import logging
 
 from django.test import TestCase
 
-from plugins.models import Plugin, PluginParameter
+from plugins.models import Plugin
+from plugins.models import PluginParameter, DefaultPathParameter
 from plugins.models import ComputeResource
 
 
-class PluginModelTests(TestCase):
-    
+class ModelTests(TestCase):
+
     def setUp(self):
         # avoid cluttered console output (for instance logging all the http requests)
         logging.disable(logging.CRITICAL)
 
         self.plugin_fs_name = "simplefsapp"
-        self.plugin_fs_parameters = {'dir': {'type': 'string', 'optional': False}}
+        self.plugin_fs_parameters = {'dir': {'type': 'path', 'optional': True,
+                                             'default': "./"}}
         (self.compute_resource, tf) = ComputeResource.objects.get_or_create(
                                                         compute_resource_identifier="host")
         # create a plugin
@@ -22,17 +24,38 @@ class PluginModelTests(TestCase):
                                                     type='fs',
                                                     compute_resource=self.compute_resource)
         # add plugins' parameters
-        PluginParameter.objects.get_or_create(
+        (plg_param, tf) = PluginParameter.objects.get_or_create(
             plugin=plugin_fs,
             name='dir',
             type=self.plugin_fs_parameters['dir']['type'],
-            optional=self.plugin_fs_parameters['dir']['optional'])
+            optional=self.plugin_fs_parameters['dir']['optional']
+        )
+        default = self.plugin_fs_parameters['dir']['default']
+        DefaultPathParameter.objects.get_or_create(plugin_param=plg_param, value=default)
+
+    def tearDown(self):
+        # re-enable logging
+        logging.disable(logging.DEBUG)
+
+
+class PluginModelTests(ModelTests):
+    """
+    Test the PluginModel model.
+    """
 
     def test_get_plugin_parameter_names(self):
         plugin = Plugin.objects.get(name=self.plugin_fs_name)
         param_names = plugin.get_plugin_parameter_names()
         self.assertEqual(param_names, ['dir'])
 
-    def tearDown(self):
-        # re-enable logging
-        logging.disable(logging.DEBUG)
+
+class PluginParameterModelTests(ModelTests):
+    """
+    Test the PluginParameter model.
+    """
+
+    def test_get_default(self):
+        plugin = Plugin.objects.get(name=self.plugin_fs_name)
+        parameter = plugin.parameters.get(name='dir')
+        default = parameter.get_default()
+        self.assertEqual(default.value, "./")

--- a/chris_backend/plugins/tests/test_serializers.py
+++ b/chris_backend/plugins/tests/test_serializers.py
@@ -5,7 +5,9 @@ from unittest import mock
 from django.test import TestCase
 from rest_framework import serializers
 
-from plugins.models import Plugin, PluginParameter, ComputeResource
+from plugins.models import Plugin
+from plugins.models import PluginParameter, DefaultPathParameter
+from plugins.models import ComputeResource
 from plugins.serializers import PluginSerializer
 
 
@@ -40,11 +42,15 @@ class SerializerTests(TestCase):
         (plugin, tf) = Plugin.objects.get_or_create(**data)
 
         # add plugin's parameters
-        PluginParameter.objects.get_or_create(
+        (plg_param, tf) = PluginParameter.objects.get_or_create(
             plugin=plugin,
             name=parameters[0]['name'],
             type=parameters[0]['type'],
-            flag=parameters[0]['flag'])
+            flag=parameters[0]['flag'],
+            optional=parameters[0]['optional']
+        )
+        default = parameters[0]['default']
+        DefaultPathParameter.objects.get_or_create(plugin_param=plg_param, value=default)
 
     def tearDown(self):
         # re-enable logging


### PR DESCRIPTION
…atedTagOwnerOrChris' docstring

Add test_get_creator test method

Add FeedPluginInstanceListViewTests test class

Make get_default method return a default parameter instance instead of the instance.value

Fix get_default method in PluginParameter's serializer to work with the corresponding get_default method in the model

Remove legacy code

Fix the tests to work with the new model, serializers and views in the plugins app

Fix docstring in get_pipings_parameters_names

Add more unit tests

Change method name checkParameterDefaultValues --> check_parameter_default_values

Use the new check_parameter_default_values method in PipelineSerializer

Add more unit tests

Fix param name bug

Add more unit tests for pipelines and pipelineinstances apps

Add unit tests for pipelineinstances' views

Add a comprehensive set of Unit tests and some bug fixes.