### PR TITLE
Add started_jobs, finished_jobs, errored_jobs and cancelled_jobs API descriptors to feeds' representations.

### DIFF
--- a/chris_backend/feeds/models.py
+++ b/chris_backend/feeds/models.py
@@ -40,6 +40,13 @@ class Feed(models.Model):
         plg_inst = self.plugin_instances.filter(plugin__type='fs')[0]
         return plg_inst.owner
 
+    def get_plugin_instances_status_count(self, status):
+        """
+        Custom method to get the number of associated plugin instances with a given
+        execution status.
+        """
+        return self.plugin_instances.filter(status=status).count()
+
 
 class FeedFilter(FilterSet):
     min_id = django_filters.NumberFilter(field_name="id", lookup_expr='gte')

--- a/chris_backend/feeds/serializers.py
+++ b/chris_backend/feeds/serializers.py
@@ -4,6 +4,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db.utils import IntegrityError
 from rest_framework import serializers
 
+from plugininstances.models import STATUS_TYPES
 from .models import Note, Feed, Tag, Tagging, Comment
 
 
@@ -91,6 +92,10 @@ class TaggingSerializer(serializers.HyperlinkedModelSerializer):
 
 class FeedSerializer(serializers.HyperlinkedModelSerializer):
     creator_username = serializers.SerializerMethodField()
+    started_jobs = serializers.SerializerMethodField()
+    finished_jobs = serializers.SerializerMethodField()
+    errored_jobs = serializers.SerializerMethodField()
+    cancelled_jobs = serializers.SerializerMethodField()
     note = serializers.HyperlinkedRelatedField(view_name='note-detail', read_only=True)
     tags = serializers.HyperlinkedIdentityField(view_name='feed-tag-list')
     taggings = serializers.HyperlinkedIdentityField(view_name='feed-tagging-list')
@@ -104,7 +109,8 @@ class FeedSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Feed
         fields = ('url', 'id', 'creation_date', 'modification_date', 'name',
-                  'creator_username', 'owner', 'note', 'tags', 'taggings', 'comments',
+                  'creator_username', 'started_jobs', 'finished_jobs', 'errored_jobs',
+                  'cancelled_jobs', 'owner', 'note', 'tags', 'taggings', 'comments',
                   'files', 'plugin_instances')
 
     def validate_new_owner(self, username):
@@ -124,6 +130,40 @@ class FeedSerializer(serializers.HyperlinkedModelSerializer):
         Overriden to get the username of the creator of the feed.
         """
         return obj.get_creator().username
+
+    def get_started_jobs(self, obj):
+        """
+        Overriden to get the number of plugin instances in 'started' status.
+        """
+        if 'started' not in STATUS_TYPES:
+            raise KeyError("Undefined plugin instance execution status: 'started'.")
+        return obj.get_plugin_instances_status_count('started')
+
+    def get_finished_jobs(self, obj):
+        """
+        Overriden to get the number of plugin instances in 'finishedSuccessfully' status.
+        """
+        if 'finishedSuccessfully' not in STATUS_TYPES:
+            raise KeyError("Undefined plugin instance execution status: "
+                           "'finishedSuccessfully'.")
+        return obj.get_plugin_instances_status_count('finishedSuccessfully')
+
+    def get_errored_jobs(self, obj):
+        """
+        Overriden to get the number of plugin instances in 'finishedWithError' status.
+        """
+        if 'finishedWithError' not in STATUS_TYPES:
+            raise KeyError("Undefined plugin instance execution status: "
+                           "'finishedWithError'.")
+        return obj.get_plugin_instances_status_count('finishedWithError')
+
+    def get_cancelled_jobs(self, obj):
+        """
+        Overriden to get the number of plugin instances in 'cancelled' status.
+        """
+        if 'cancelled' not in STATUS_TYPES:
+            raise KeyError("Undefined plugin instance execution status: 'cancelled'.")
+        return obj.get_plugin_instances_status_count('cancelled')
 
 
 class CommentSerializer(serializers.HyperlinkedModelSerializer):


### PR DESCRIPTION
Add get_plugin_instances_status_count method to Feed model.

Add started_jobs, finished_jobs, errored_jobs and cancelled_jobs fields to FeedSerializer.