### PR TITLE
Add job ID prefix

### DIFF
--- a/chris_backend/plugininstances/services/charm.py
+++ b/chris_backend/plugininstances/services/charm.py
@@ -117,6 +117,10 @@ class Charm():
         self.LC                     = 40
         self.RC                     = 40
 
+        # A job ID prefix string. Necessary since some schedulers require
+        # a minimum job ID string length
+        self.str_jidPrefix          = '000'
+
         for key, val in kwargs.items():
             if key == 'app_args':       self.l_appArgs         = val
             if key == 'd_args':         self.d_args            = val
@@ -803,7 +807,7 @@ class Charm():
             if self.str_inputdir == '':
                 d_fs    = self.app_service_fsplugin_setup()
                 self.str_inputdir   = d_fs['d_manage']['d_handle']['inputdir']
-            str_serviceName = str(self.d_pluginInst['id'])
+            str_serviceName = self.str_jidPrefix + str(self.d_pluginInst['id'])
             d_msg = \
             {   
                 "action": "coordinate",
@@ -853,7 +857,7 @@ class Charm():
                     'cmd':               "%s %s" % (self.c_pluginInst.plugin.execshell, self.str_cmd),
                     'threaded':          True,
                     'auid':              self.c_pluginInst.owner.username,
-                    'jid':               str(self.d_pluginInst['id']),
+                    'jid':               str_serviceName,
                     'number_of_workers': str(self.d_pluginInst['number_of_workers']),
                     'cpu_limit':         str(self.d_pluginInst['cpu_limit']),
                     'memory_limit':      str(self.d_pluginInst['memory_limit']),
@@ -960,7 +964,7 @@ class Charm():
             "action": "status",
             "meta": {
                     "remote": {
-                        "key":       str(self.d_pluginInst['id'])
+                        "key":       self.str_jidPrefix + str(self.d_pluginInst['id'])
                     }
             }
         }
@@ -1064,7 +1068,7 @@ class Charm():
             "action": "search",
             "meta": {
                 "key":      "jid",
-                "value":    str(self.d_pluginInst['id']),
+                "value":    self.str_jidPrefix + str(self.d_pluginInst['id']),
                 "job":      "0",
                 "when":     "end",
                 "field":    "stderr"

--- a/chris_backend/plugininstances/services/charm.py
+++ b/chris_backend/plugininstances/services/charm.py
@@ -119,7 +119,7 @@ class Charm():
 
         # A job ID prefix string. Necessary since some schedulers require
         # a minimum job ID string length
-        self.str_jidPrefix          = '000'
+        self.str_jidPrefix          = 'chris-jid-'
 
         for key, val in kwargs.items():
             if key == 'app_args':       self.l_appArgs         = val

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,7 +7,7 @@ python-swiftclient==3.6.0
 django-storage-swift==1.2.19
 mod-wsgi==4.6.5
 collection-json==0.1.1
-pfurl>=1.3.20.0
+pfurl>=2.1.2.2
 pfmisc>=1.3.30
 pytz==2016.7
 python-chrisstoreclient==0.1.1


### PR DESCRIPTION
Prefix jid with a string. Currently hard-coded in the base class. 
Prefix necessary to increase jid string length for openshift.