### PR TITLE
Set root path in swift to user and not user/uploadswq

### DIFF
--- a/chris_backend/plugininstances/services/charm.py
+++ b/chris_backend/plugininstances/services/charm.py
@@ -375,7 +375,11 @@ class Charm():
             d_ret['status'] = False
 
         if b_prependBucketPath:
-            d_ret['prependBucketPath']  = self.c_pluginInst.owner.username + '/uploads'
+            # d_ret['prependBucketPath']  = self.c_pluginInst.owner.username + '/uploads'
+	    # The following line should "root" requests to swift storage to the user
+	    # space and allow for access/dircopy to the feed space and not only 
+	    # the 'uploads' space.
+            d_ret['prependBucketPath']  = self.c_pluginInst.owner.username
 
         return d_ret
 


### PR DESCRIPTION
WIP test ... by setting the swift base bucket "prepend" path to only the <username> pattern and not <username>/uploads we should be able to ``dircopy --dir`` from locations in both the uploads and feed tree spaces.
