### PR TITLE
Remove final prepend string spec from charm filename space

### DIFF
--- a/chris_backend/plugininstances/services/charm.py
+++ b/chris_backend/plugininstances/services/charm.py
@@ -379,7 +379,8 @@ class Charm():
 	    # The following line should "root" requests to swift storage to the user
 	    # space and allow for access/dircopy to the feed space and not only 
 	    # the 'uploads' space.
-            d_ret['prependBucketPath']  = self.c_pluginInst.owner.username
+            # d_ret['prependBucketPath']  = self.c_pluginInst.owner.username
+            d_ret['prependBucketPath']  = ''
 
         return d_ret
 


### PR DESCRIPTION
Charm used to prepend paths with chris <username> and ('uploads' where contextually relevant) since fnames returned from the BE did not return the <username> and for uploads did not require an explicit 'upload' string either.

Now charm assumes that fnames are fully expressive.

