### PR TITLE
Change outdated *make* syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ running with no mess, no fuss:
 git clone https://github.com/FNNDSC/ChRIS_ultron_backend
 cd ChRIS_ultron_backend
 # Run full CUBE instantiation with tests:
-*unmake* ; sudo rm -fr FS; rm -fr FS; *make*
+./unmake.sh ; sudo rm -fr FS; rm -fr FS; ./make.sh
 
 # Skip unit and integration tests and the intro:
-*unmake* ; sudo rm -fr FS; rm -fr FS; *make* -U -I -s
+./unmake.sh ; sudo rm -fr FS; rm -fr FS; ./make.sh -U -I -s
 ```
 The resulting instance uses the default Django development server and therefore is not suitable for production.
 

--- a/make.sh
+++ b/make.sh
@@ -26,11 +26,11 @@
 #
 #   Run full CUBE instantiation with tests:
 #
-#       unmake.sh ; sudo rm -fr FS; rm -fr FS; make.sh
+#       ./unmake.sh ; sudo rm -fr FS; rm -fr FS; ./make.sh
 #
 #   Skip unit and integration tests and the intro:
 #
-#       unmake.sh ; sudo rm -fr FS; rm -fr FS; make.sh -U -I -s
+#       ./unmake.sh ; sudo rm -fr FS; rm -fr FS; ./make.sh -U -I -s
 #
 # ARGS
 #


### PR DESCRIPTION
Add documents to fix issues that I faced on Fedora 32.

I am running the installation steps on `README.md` on my local machine, Fedora 32.
Here are some suggestions to update it.  The steps are until `./make.sh` part which I am still trying to run.

## 1. Not everyone set `PATH` adding the current directory `.`. In the environment, `*unmake*` and `*make*` do not work.

  ```
  $ *unmake*
  bash: unmake.sh: command not found...
  ```

  ```
  $ *make*
  bash: make.sh: command not found...
  ```

  I think `./make.sh` and `./unmake.sh` are better.

## 2. In the current `README.md`, the command prompt such as `$` is not written. In this situation, it's hard to distinguish between the command line and the output. So, when we need to show the output of the command, I added `$` as a command prompt. It is the format used in [Docker's document](https://docs.docker.com/engine/install/linux-postinstall/).

  ```
  $ ./make.sh
  ERROR: for chris_ultron_backend_queue_1  Cannot start service queue: OCI runtime create failed: this ve
rsion of runc doesn't work on cgroups v2: unknown
  ```

## 3. Add possible error cases.

I am not sure if the places where I added the document is proper.

3.1. When people uses new Linux distribution where the kernel cgroups v2 is available, but cgroups v1 is not available, we need to enable cgroups v1 then restart Linux OS.

3.2. When docker deamon is running with `--live-restore` option, `docker swarm init` fails. I needed to remove the option from the config file `/etc/sysconfig/docker` like this, then restart docker daemon.

```
$ cat /etc/sysconfig/docker
# /etc/sysconfig/docker

# Modify these options if you want to change the way the docker daemon runs
# OPTIONS="--selinux-enabled \
#   --log-driver=journald \
#   --storage-driver=overlay2 \
#   --live-restore \
#   --default-ulimit nofile=1024:1024 \
#   --init-path /usr/libexec/docker/docker-init \
#   --userland-proxy-path /usr/libexec/docker/docker-proxy \
# "
OPTIONS="--selinux-enabled \
  --log-driver=journald \
  --storage-driver=overlay2 \
  --default-ulimit nofile=1024:1024 \
  --init-path /usr/libexec/docker/docker-init \
  --userland-proxy-path /usr/libexec/docker/docker-proxy \
"
```

3.3. First when I executed `./unmake.sh` I had no idea about that the following error is valid or not.

```
$ ./unmake.sh
...
│Error response from daemon: This node is not part of a swarm                    │▒
```

