### PR TITLE
Add :z to docker-compose_dev.yml

### DIFF
--- a/docker-compose_dev.yml
+++ b/docker-compose_dev.yml
@@ -7,6 +7,9 @@
 # EXPOSE, VOLUME, ENV) are respected by default - you don't need to
 # specify them again in docker-compose.yml.
 #
+# Fedora (and RHEL, CentOS) use SELinux.
+# Docker needs :z volume mount options to provide a context label.
+# See man docker-run
 
 version: '3.7'
 
@@ -15,7 +18,7 @@ services:
   chris_dev:
     image: ${CHRISREPO}/chris:dev
     volumes:
-      - ./chris_backend:/home/localuser/chris_backend
+      - ./chris_backend:/home/localuser/chris_backend:z
     environment:
       - CHRIS_DEBUG_QUIET
     ports:
@@ -33,7 +36,7 @@ services:
   worker:
     image: ${CHRISREPO}/chris:dev
     volumes:
-      - ./chris_backend:/home/localuser/chris_backend
+      - ./chris_backend:/home/localuser/chris_backend:z
     entrypoint: ''
     command: celery -A core worker -c 1 -l DEBUG -Q main
     environment:
@@ -52,7 +55,7 @@ services:
   chris_dev_db:
     image: mysql:5
     volumes:
-      - chris_dev_db_data:/var/lib/mysql
+      - chris_dev_db_data:/var/lib/mysql:z
     environment:
       - MYSQL_ROOT_PASSWORD=rootp
       - MYSQL_DATABASE=chris_dev
@@ -98,7 +101,7 @@ services:
   chris_store_db:
     image: mysql:5
     volumes:
-      - chris_store_db_data:/var/lib/mysql
+      - chris_store_db_data:/var/lib/mysql:z
     environment:
       - MYSQL_ROOT_PASSWORD=rootp
       - MYSQL_DATABASE=chris_store
@@ -112,7 +115,7 @@ services:
     image: ${SWIFTREPO}/docker-swift-onlyone
     init: true
     volumes:
-      - swift_storage_dev:/srv
+      - swift_storage_dev:/srv:z
     environment:
       - SWIFT_USERNAME=chris:chris1234
       - SWIFT_KEY=testing
@@ -125,7 +128,7 @@ services:
   pfcon_service:
     image: ${PFCONREPO}/pfcon${TAG}
     volumes:
-      - ./FS/data:/data
+      - ./FS/data:/data:z
     command: ["--forever", "--httpResponse", "--verbosity", "1"]
     ports:
       - "5005:5005"
@@ -144,7 +147,7 @@ services:
     image: ${PFIOHREPO}/pfioh${TAG}
     command: ["--forever", "--httpResponse", "--createDirsAsNeeded", "--storeBase", "/hostFS/storeBase", "--verbosity", "1"]
     volumes:
-      - ./FS/remote:/hostFS/storeBase
+      - ./FS/remote:/hostFS/storeBase:z
     ports:
       - "5055:5055"
     labels:
@@ -172,8 +175,8 @@ services:
     image: ${PMANREPO}/pman${TAG}
     command: ["--rawmode", "1", "--http", "--port", "5010", "--listeners", "12", "--verbosity", "1"]
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - ./FS/remote:/hostFS/storeBase
+      - /var/run/docker.sock:/var/run/docker.sock:z
+      - ./FS/remote:/hostFS/storeBase:z
     ports:
       - "5010:5010"
     labels:


### PR DESCRIPTION
This PR is a cherry pick from z-vol branch that is used to make it work on Fedora 31 VM environment enabling SELinux enabled (mode: enforcing) [1] and coming from https://github.com/FNNDSC/ChRIS_ultron_backEnd/issues/215#issuecomment-668718348 .

https://github.com/FNNDSC/ChRIS_ultron_backEnd/wiki/Fedora-32-Support-for-Docker
  > I created a branch z-vol to demonstrate how this works.

I wish this PR will be merged to support the platform enabling SELinux (mode: enforcing).
When [Ubuntu enables SELinux](https://wiki.ubuntu.com/SELinux), it possibly needs this patch too. Fedora is enabling it as a default setting.

