### PR TITLE
Make faster integration tests and stronger validation of parameters of type 'path' and 'unextpath'

### DIFF
--- a/chris_backend/users/tests/test_serializers.py
+++ b/chris_backend/users/tests/test_serializers.py
@@ -1,11 +1,15 @@
 
 import logging
 
+
+from unittest import mock
+
 from django.test import TestCase
 
 from rest_framework import serializers
 
-from users.serializers import UserSerializer
+from uploadedfiles.models import UploadedFile
+from users.serializers import UserSerializer, SwiftManager
 
 
 class UserSerializerTests(TestCase):
@@ -27,16 +31,27 @@ class UserSerializerTests(TestCase):
 
     def test_create(self):
         """
-        Test whether overriden create method takes care of the password hashing.
+        Test whether overriden create method takes care of the password hashing and
+        creates a welcome file for the user in its personal storage space.
         """
         user_serializer = UserSerializer()
         validated_data = {'username': self.username, 'password': self.password,
                           'email': self.email}
-        user = user_serializer.create(validated_data)
-        self.assertEqual(user.username, self.username)
-        self.assertEqual(user.email, self.email)
-        self.assertNotEqual(user.password, self.password)
-        self.assertTrue(user.check_password(self.password))
+        with mock.patch.object(SwiftManager, 'upload_obj',
+                               return_value=None) as upload_obj_mock:
+
+            user = user_serializer.create(validated_data)
+
+            self.assertEqual(user.username, self.username)
+            self.assertEqual(user.email, self.email)
+            self.assertNotEqual(user.password, self.password)
+            self.assertTrue(user.check_password(self.password))
+
+            welcome_file_path = '%s/uploads/welcome.txt' % self.username
+            welcome_file = UploadedFile.objects.get(owner=user)
+            self.assertEqual(welcome_file.fname.name, welcome_file_path)
+            upload_obj_mock.assert_called_with(welcome_file_path, mock.ANY,
+                                               content_type='text/plain')
 
     def test_validate_username(self):
         """

--- a/make.sh
+++ b/make.sh
@@ -648,31 +648,18 @@ else
         docker-compose -f docker-compose_dev.yml                        \
             exec chris_dev /bin/bash -c                                 \
             'python manage.py createsuperuser --noinput --username chris --email dev@babymri.org 2> /dev/null;' >& dc.out >/dev/null
-        echo -en "\033[2A\033[2K"
-        cat dc.out | ./boxes.sh
-
-        echo "Saving superuser chris:chris1234..."                      | ./boxes.sh
-        windowBottom
         docker-compose -f docker-compose_dev.yml                        \
-            exec chris_dev /bin/bash -c \
-            'python manage.py shell -c "from django.contrib.auth.models import User; user = User.objects.get(username=\"chris\"); user.set_password(\"chris1234\"); user.save()"' >& dc.out >/dev/null
+            exec chris_dev /bin/bash -c                                 \
+            'python manage.py shell -c "from django.contrib.auth.models import User; user=User.objects.get(username=\"chris\"); user.set_password(\"chris1234\"); user.save()"' >& dc.out >/dev/null
         echo -en "\033[2A\033[2K"
         cat dc.out | ./boxes.sh
 
         echo ""                                                         | ./boxes.sh
-        echo "Setting superuser user cube:cube1234..."                  | ./boxes.sh
+        echo "Setting normal user cube:cube1234..."                     | ./boxes.sh
         windowBottom
         docker-compose -f docker-compose_dev.yml                        \
             exec chris_dev /bin/bash -c                                 \
-            'python manage.py createsuperuser --noinput --username cube --email dev@babymri.org 2> /dev/null;' >& dc.out >/dev/null
-        echo -en "\033[2A\033[2K"
-        cat dc.out | ./boxes.sh
-
-        echo "Saving superuser user cube:cube1234..."                   | ./boxes.sh
-        windowBottom
-        docker-compose -f docker-compose_dev.yml                        \
-            exec chris_dev /bin/bash -c                                 \
-            'python manage.py shell -c "from django.contrib.auth.models import User; user = User.objects.get(username=\"cube\"); user.set_password(\"cube1234\"); user.save()"' >& dc.out >/dev/null
+            'python manage.py shell -c "from users.serializers import UserSerializer; us=UserSerializer(data={\"username\":\"cube\",\"password\":\"cube1234\",\"email\":\"cube@babymri.org\"}); us.is_valid(); us.save()"' >& dc.out >/dev/null
         echo -en "\033[2A\033[2K"
         cat dc.out | ./boxes.sh
     windowBottom


### PR DESCRIPTION
- Stronger validation of parameters of type 'path' and 'unextpath' so the plugin instance manager does  not have to deal with invalid dirs
- Faster integration tests
- A welcome to ChRIS `welcome.txt` file is automatically created in the user's personal space when they sign up for a ChRIS account. This allows example API calls in the README to continue to work even with the new stronger validation of parameters