### PR TITLE
Implement on the fly plugin instance tree workflows

### DIFF
--- a/chris_backend/core/api.py
+++ b/chris_backend/core/api.py
@@ -236,6 +236,10 @@ urlpatterns = format_suffix_patterns([
         plugininstance_views.PathParameterDetail.as_view(),
         name='pathparameter-detail'),
 
+    path('v1/plugins/unextpath-parameter/<int:pk>/',
+         plugininstance_views.UnextpathParameterDetail.as_view(),
+         name='unextpathparameter-detail'),
+
 
     path('v1/pipelines/<int:pk>/instances/',
         pipelineinstance_views.PipelineInstanceList.as_view(),

--- a/chris_backend/core/celery.py
+++ b/chris_backend/core/celery.py
@@ -25,15 +25,16 @@ app.autodiscover_tasks()
 task_routes = {
     'plugininstances.tasks.sum': {'queue': 'main'},
     'plugininstances.tasks.check_plugin_instance_exec_status': {'queue': 'main'},
-    'plugininstances.tasks.check_started_plugin_instances_exec_status': {'queue': 'main'},
+    'plugininstances.tasks.check_scheduled_plugin_instances_exec_status':
+        {'queue': 'main'},
     'plugininstances.tasks.run_plugin_instance': {'queue': 'main'},
 }
 app.conf.update(task_routes=task_routes)
 
 # setup periodic tasks
 app.conf.beat_schedule = {
-    'check-started-plugin-instances-exec-status-every-10-seconds': {
-        'task': 'plugininstances.tasks.check_started_plugin_instances_exec_status',
+    'check-scheduled-plugin-instances-exec-status-every-10-seconds': {
+        'task': 'plugininstances.tasks.check_scheduled_plugin_instances_exec_status',
         'schedule': 10.0,
     },
 }

--- a/chris_backend/plugininstances/models.py
+++ b/chris_backend/plugininstances/models.py
@@ -21,7 +21,8 @@ from .services.manager import PluginInstanceManager
 logger = logging.getLogger(__name__)
 
 
-STATUS_TYPES = ['started', 'finishedSuccessfully', 'finishedWithError', 'cancelled']
+STATUS_TYPES = ['started', 'waitingForPrevious', 'finishedSuccessfully',
+                'finishedWithError', 'cancelled']
 
 
 class PluginInstance(models.Model):
@@ -208,8 +209,9 @@ class PluginInstance(models.Model):
         """
         Custom method to run the app corresponding to this plugin instance.
         """
-        plg_inst_manager = PluginInstanceManager(self)
-        plg_inst_manager.run_plugin_instance_app()
+        if self.status == 'started':
+            plg_inst_manager = PluginInstanceManager(self)
+            plg_inst_manager.run_plugin_instance_app()
 
     def check_exec_status(self):
         """

--- a/chris_backend/plugininstances/tasks.py
+++ b/chris_backend/plugininstances/tasks.py
@@ -1,4 +1,6 @@
 
+from django.db.models import Q
+
 from celery import shared_task
 
 from .models import PluginInstance
@@ -24,14 +26,24 @@ def check_plugin_instance_exec_status(plg_inst_id):
 
 
 @shared_task
-def check_started_plugin_instances_exec_status():
+def check_scheduled_plugin_instances_exec_status():
     """
     Check the execution status of the apps corresponding to all the plugin instances
-    with 'started' DB status.
+    with 'started' or 'waitingForPrevious' DB status.
     """
-    instances = PluginInstance.objects.filter(status='started')
-    for plugin_inst in instances:
-        check_plugin_instance_exec_status.delay(plugin_inst.id)  # call async task
+    lookup = Q(status='started') | Q(status='waitingForPrevious')
+    instances = PluginInstance.objects.filter(lookup)
+    for plg_inst in instances:
+        if plg_inst.status == 'waitingForPrevious':
+            if plg_inst.previous.status == 'finishedSuccessfully':
+                plg_inst.status = 'started'
+                plg_inst.save()
+                run_plugin_instance.delay(plg_inst.id)  # call async task
+            elif plg_inst.previous.status in ('finishedWithError', 'cancelled'):
+                plg_inst.status = 'cancelled'
+                plg_inst.save()
+        else:
+            check_plugin_instance_exec_status.delay(plg_inst.id)  # call async task
 
 
 @shared_task  # toy task for testing celery stuff

--- a/chris_backend/plugininstances/tests/test_models.py
+++ b/chris_backend/plugininstances/tests/test_models.py
@@ -250,6 +250,7 @@ class PluginInstanceModelTests(ModelTests):
             plugin=plugin, owner=user, compute_resource=plugin.compute_resources.all()[0])
 
         self.assertEqual(plg_inst.status, 'started')
+
         with mock.patch.object(
                 PluginInstanceManager,
                 'cancel_plugin_instance_app_exec',
@@ -259,45 +260,73 @@ class PluginInstanceModelTests(ModelTests):
             manager_cancel_plugin_instance_app_exec_mock.assert_called_once()
         self.assertEqual(plg_inst.status, 'cancelled')
 
+        with mock.patch.object(
+                PluginInstanceManager,
+                'cancel_plugin_instance_app_exec',
+                return_value=None) as manager_cancel_plugin_instance_app_exec_mock:
+            # for any status different from 'started' check that manager's method was not called
+            plg_inst.status = 'finishedSuccessfully'
+            plg_inst.cancel()
+            manager_cancel_plugin_instance_app_exec_mock.assert_not_called()
+        self.assertEqual(plg_inst.status, 'finishedSuccessfully')
+
     def test_run(self):
         """
         Test whether custom run method starts the execution of the app corresponding
         to a plugin instance.
         """
+        user = User.objects.get(username=self.username)
+        plugin = Plugin.objects.get(meta__name=self.plugin_fs_name)
+        plg_inst = PluginInstance.objects.create(
+            plugin=plugin,
+            owner=user,
+            compute_resource=plugin.compute_resources.all()[0]
+        )
+        self.assertEqual(plg_inst.status, 'started')
+
         with mock.patch.object(PluginInstanceManager, 'run_plugin_instance_app',
                                return_value=None) as run_plugin_instance_app_mock:
-            user = User.objects.get(username=self.username)
-            plugin = Plugin.objects.get(meta__name=self.plugin_fs_name)
-            plg_inst = PluginInstance.objects.create(
-                plugin=plugin,
-                owner=user,
-                compute_resource=plugin.compute_resources.all()[0]
-            )
-            self.assertEqual(plg_inst.status, 'started')
             plg_inst.run()
             self.assertEqual(plg_inst.status, 'started')
             # check that manager's run_plugin_instance_app method was called with appropriate args
             run_plugin_instance_app_mock.assert_called_with()
+
+        with mock.patch.object(PluginInstanceManager, 'run_plugin_instance_app',
+                               return_value=None) as run_plugin_instance_app_mock:
+            # for any status different from 'started' check that manager's method was not called
+            plg_inst.status = 'waitForPrevious'
+            plg_inst.run()
+            run_plugin_instance_app_mock.assert_not_called()
 
     def test_check_exec_status(self):
         """
         Test whether custom check_exec_status method checks the execution status of the
         app corresponding to a plugin instance.
         """
+        user = User.objects.get(username=self.username)
+        plugin = Plugin.objects.get(meta__name=self.plugin_fs_name)
+        plg_inst = PluginInstance.objects.create(
+            plugin=plugin,
+            owner=user,
+            compute_resource=plugin.compute_resources.all()[0]
+        )
+
         with mock.patch.object(
                 PluginInstanceManager,
                 'check_plugin_instance_app_exec_status',
                 return_value=None) as check_plugin_instance_app_exec_status_mock:
-            user = User.objects.get(username=self.username)
-            plugin = Plugin.objects.get(meta__name=self.plugin_fs_name)
-            plg_inst = PluginInstance.objects.create(
-                plugin=plugin,
-                owner=user,
-                compute_resource=plugin.compute_resources.all()[0]
-            )
             plg_inst.check_exec_status()
             # check that manager's check_plugin_instance_app_exec_status method was called once
             check_plugin_instance_app_exec_status_mock.assert_called_once()
+
+        with mock.patch.object(
+                PluginInstanceManager,
+                'check_plugin_instance_app_exec_status',
+                return_value=None) as check_plugin_instance_app_exec_status_mock:
+            # for any status different from 'started' check that manager's method was not called
+            plg_inst.status = 'waitForPrevious'
+            plg_inst.check_exec_status()
+            check_plugin_instance_app_exec_status_mock.assert_not_called()
 
 
 class PluginInstanceFilterModelTests(ModelTests):

--- a/chris_backend/plugininstances/tests/test_tasks.py
+++ b/chris_backend/plugininstances/tests/test_tasks.py
@@ -1,0 +1,125 @@
+
+import logging
+from unittest import mock, skip
+
+from django.test import TestCase, tag
+from django.contrib.auth.models import User
+from django.conf import settings
+
+from plugins.models import PluginMeta, Plugin, ComputeResource
+from plugininstances.models import PluginInstance
+
+from plugininstances import tasks
+
+
+COMPUTE_RESOURCE_URL = settings.COMPUTE_RESOURCE_URL
+
+
+class TasksTests(TestCase):
+
+    def setUp(self):
+        # avoid cluttered console output (for instance logging all the http requests)
+        logging.disable(logging.WARNING)
+
+        self.username = 'foo'
+        self.password = 'bar'
+
+        (self.compute_resource, tf) = ComputeResource.objects.get_or_create(
+            name="host", compute_url=COMPUTE_RESOURCE_URL)
+
+        # create the chris user
+        User.objects.create_user(username=self.username, password=self.password)
+
+        # create two plugins
+        (pl_meta, tf) = PluginMeta.objects.get_or_create(name='pacspull', type='fs')
+        (plugin_fs, tf) = Plugin.objects.get_or_create(meta=pl_meta, version='0.1')
+        plugin_fs.compute_resources.set([self.compute_resource])
+        plugin_fs.save()
+
+        (pl_meta, tf) = PluginMeta.objects.get_or_create(name='mri_convert', type='ds')
+        (plugin_ds, tf) = Plugin.objects.get_or_create(meta=pl_meta, version='0.1')
+        plugin_ds.compute_resources.set([self.compute_resource])
+        plugin_ds.save()
+
+    def tearDown(self):
+        # re-enable logging
+        logging.disable(logging.NOTSET)
+
+
+class PluginInstanceTasksTests(TasksTests):
+    """
+    Test the plugin instance tasks.
+    """
+
+    def setUp(self):
+        super(PluginInstanceTasksTests, self).setUp()
+        plugin = Plugin.objects.get(meta__name="pacspull")
+        # create a plugin's instance
+        user = User.objects.get(username=self.username)
+        (self.plg_inst, tf) = PluginInstance.objects.get_or_create(
+            plugin=plugin,
+            owner=user,
+            compute_resource=plugin.compute_resources.all()[0])
+
+    def test_task_run_plugin_instance(self):
+        with mock.patch.object(tasks.PluginInstance, 'run',
+                               return_value=None) as run_mock:
+            tasks.run_plugin_instance(self.plg_inst.id)
+            run_mock.assert_called_with()
+
+    def test_task_check_plugin_instance_exec_status(self):
+        with mock.patch.object(tasks.PluginInstance, 'check_exec_status',
+                               return_value=None) as check_exec_status_mock:
+            tasks.check_plugin_instance_exec_status(self.plg_inst.id)
+            check_exec_status_mock.assert_called_with()
+
+    def test_task_check_scheduled_plugin_instances_exec_status(self):
+        with mock.patch.object(tasks.check_plugin_instance_exec_status, 'delay',
+                               return_value=None) as delay_mock:
+            tasks.check_scheduled_plugin_instances_exec_status()
+
+            # check that the check_plugin_instance_exec_status task was called with appropriate args
+            delay_mock.assert_called_with(self.plg_inst.id)
+            self.assertEqual(self.plg_inst.status, 'started')
+
+        # create mri_convert ds plugin instance
+        previous_plg_inst = self.plg_inst
+        user = User.objects.get(username=self.username)
+        plugin = Plugin.objects.get(meta__name="mri_convert")
+        (plg_inst, tf) = PluginInstance.objects.get_or_create(
+            plugin=plugin, owner=user, previous=previous_plg_inst,
+            compute_resource=plugin.compute_resources.all()[0])
+
+        plg_inst.status = 'waitingForPrevious'
+        plg_inst.save()
+        previous_plg_inst.status = 'finishedSuccessfully'
+        previous_plg_inst.save()
+        with mock.patch.object(tasks.check_plugin_instance_exec_status, 'delay',
+                               return_value=None) as check_status_delay_mock:
+            with mock.patch.object(tasks.run_plugin_instance, 'delay',
+                                   return_value=None) as run_delay_mock:
+                tasks.check_scheduled_plugin_instances_exec_status()
+                plg_inst.refresh_from_db()
+                self.assertEqual(plg_inst.status, 'started')
+
+                # check that the check_plugin_instance_exec_status task was not called
+                check_status_delay_mock.assert_not_called()
+                # check that the run_plugin_instance task was called with appropriate args
+                run_delay_mock.assert_called_with(plg_inst.id)
+
+        plg_inst.status = 'waitingForPrevious'
+        plg_inst.save()
+        previous_plg_inst.status = 'finishedWithError'
+        previous_plg_inst.save()
+        with mock.patch.object(tasks.check_plugin_instance_exec_status, 'delay',
+                               return_value=None) as check_status_delay_mock:
+            with mock.patch.object(tasks.run_plugin_instance, 'delay',
+                                   return_value=None) as run_delay_mock:
+                tasks.check_scheduled_plugin_instances_exec_status()
+                plg_inst.refresh_from_db()
+                self.assertEqual(plg_inst.status, 'cancelled')
+
+                # check that the check_plugin_instance_exec_status task was not called
+                check_status_delay_mock.assert_not_called()
+                # check that the run_plugin_instance task was not called
+                run_delay_mock.assert_not_called()


### PR DESCRIPTION
- Allow a user to run as many plugins as desired as part of a tree of plugin instances without waiting for the ancestor instance to finish
- Introduce a new `waitingForPrevious` plugin instance status