### PR TITLE
Make dev system more stable after running integration tests

### DIFF
--- a/chris_backend/plugininstances/tests/test_manager.py
+++ b/chris_backend/plugininstances/tests/test_manager.py
@@ -133,7 +133,8 @@ class PluginInstanceManagerTests(TestCase):
         user = User.objects.get(username=self.username)
         plugin = Plugin.objects.get(meta__name=self.plugin_fs_name)
         (pl_inst, tf) = PluginInstance.objects.get_or_create(
-            plugin=plugin, owner=user, compute_resource=plugin.compute_resources.all()[0])
+            title='test3', plugin=plugin,
+            owner=user, compute_resource=plugin.compute_resources.all()[0])
         pl_param = plugin.parameters.all()[0]
         PathParameter.objects.get_or_create(plugin_inst=pl_inst, plugin_param=pl_param,
                                             value=user_space_path)
@@ -143,9 +144,9 @@ class PluginInstanceManagerTests(TestCase):
 
         # delete files from swift storage
         self.swift_manager.delete_obj(user_space_path + 'test.txt')
-        obj_paths = self.swift_manager.ls(pl_inst.get_output_path())
-        for path in obj_paths:
-            self.swift_manager.delete_obj(path)
+        # obj_paths = self.swift_manager.ls(pl_inst.get_output_path())
+        # for path in obj_paths:
+        #     self.swift_manager.delete_obj(path)
 
         # finally:
         #     # remove test directory
@@ -203,7 +204,8 @@ class PluginInstanceManagerTests(TestCase):
         user = User.objects.get(username=self.username)
         plugin = Plugin.objects.get(meta__name=self.plugin_fs_name)
         (pl_inst, tf) = PluginInstance.objects.get_or_create(
-            plugin=plugin, owner=user, compute_resource=plugin.compute_resources.all()[0])
+            title='test4', plugin=plugin, owner=user,
+            compute_resource=plugin.compute_resources.all()[0])
         pl_param = plugin.parameters.all()[0]
         PathParameter.objects.get_or_create(plugin_inst=pl_inst, plugin_param=pl_param,
                                             value=user_space_path)
@@ -237,6 +239,6 @@ class PluginInstanceManagerTests(TestCase):
 
         # delete files from swift storage
         self.swift_manager.delete_obj(user_space_path + 'test.txt')
-        obj_paths = self.swift_manager.ls(pl_inst.get_output_path())
-        for path in obj_paths:
-            self.swift_manager.delete_obj(path)
+        # obj_paths = self.swift_manager.ls(pl_inst.get_output_path())
+        # for path in obj_paths:
+        #     self.swift_manager.delete_obj(path)

--- a/chris_backend/plugininstances/tests/test_views.py
+++ b/chris_backend/plugininstances/tests/test_views.py
@@ -110,8 +110,8 @@ class TasksViewTests(TransactionTestCase):
                                  password=self.chris_password)
         User.objects.create_user(username=self.other_username,
                                  password=self.other_password)
-        User.objects.create_user(username=self.username,
-                                 password=self.password)
+        user = User.objects.create_user(username=self.username,
+                                        password=self.password)
 
         # create two plugins
         (pl_meta, tf) = PluginMeta.objects.get_or_create(name='pacspull', type='fs')
@@ -123,6 +123,16 @@ class TasksViewTests(TransactionTestCase):
         (plugin_ds, tf) = Plugin.objects.get_or_create(meta=pl_meta, version='0.1')
         plugin_ds.compute_resources.set([self.compute_resource])
         plugin_ds.save()
+
+        # create pacspull fs plugin instance
+        (self.pl_inst, tf) = PluginInstance.objects.get_or_create(
+            plugin=plugin_fs, owner=user,
+            compute_resource=plugin_fs.compute_resources.all()[0])
+
+        # create mri_convert ds plugin instance
+        PluginInstance.objects.get_or_create(
+            plugin=plugin_ds, owner=user, previous=self.pl_inst,
+            compute_resource=plugin_ds.compute_resources.all()[0])
 
 
 class PluginInstanceListViewTests(TasksViewTests):
@@ -136,7 +146,8 @@ class PluginInstanceListViewTests(TasksViewTests):
         self.create_read_url = reverse("plugininstance-list", kwargs={"pk": plugin.id})
         self.user_space_path = '%s/uploads/' % self.username
         self.post = json.dumps(
-            {"template": {"data": [{"name": "dir", "value": self.user_space_path}]}})
+            {"template": {"data": [{"name": "dir", "value": self.user_space_path},
+                                   {"name": "title", "value": 'test1'}]}})
 
     def test_plugin_instance_create_success(self):
         # add parameters to the plugin before the POST request
@@ -160,11 +171,11 @@ class PluginInstanceListViewTests(TasksViewTests):
 
         # now test 'ds' plugin instance (has previous plugin instance)
 
-        previous_plg_inst = PluginInstance.objects.get(pk=1)
+        previous_plg_inst = PluginInstance.objects.get(title='test1')
         plugin = Plugin.objects.get(meta__name="mri_convert")
         create_read_url = reverse("plugininstance-list", kwargs={"pk": plugin.id})
         post = json.dumps(
-            {"template": {"data": [{"name": "previous_id", "value": 1}]}})
+            {"template": {"data": [{"name": "previous_id", "value": previous_plg_inst.id}]}})
 
         previous_plg_inst.status = 'finishedSuccessfully'
         previous_plg_inst.save()
@@ -257,9 +268,12 @@ class PluginInstanceListViewTests(TasksViewTests):
                                           content_type='text/plain')
 
         # make POST API request to create a plugin instance
-        self.create_read_url = reverse("plugininstance-list", kwargs={"pk": plugin.id})
+        create_read_url = reverse("plugininstance-list", kwargs={"pk": plugin.id})
+        post = json.dumps(
+            {"template": {"data": [{"name": "dir", "value": self.user_space_path},
+                                   {"name": "title", "value": 'test5'}]}})
         self.client.login(username=self.username, password=self.password)
-        response = self.client.post(self.create_read_url, data=self.post,
+        response = self.client.post(create_read_url, data=post,
                                     content_type=self.content_type)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
@@ -272,11 +286,6 @@ class PluginInstanceListViewTests(TasksViewTests):
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_plugin_instance_list_success(self):
-        # create a pacspull plugin instance
-        plugin = Plugin.objects.get(meta__name="pacspull")
-        user = User.objects.get(username=self.username)
-        PluginInstance.objects.get_or_create(
-            plugin=plugin, owner=user, compute_resource=plugin.compute_resources.all()[0])
         self.client.login(username=self.username, password=self.password)
         response = self.client.get(self.create_read_url)
         self.assertContains(response, "pacspull")
@@ -293,18 +302,6 @@ class PluginInstanceDetailViewTests(TasksViewTests):
 
     def setUp(self):
         super(PluginInstanceDetailViewTests, self).setUp()
-
-        # create pacspull fs plugin instance
-        plugin = Plugin.objects.get(meta__name="pacspull")
-        user = User.objects.get(username=self.username)
-        (self.pl_inst, tf) = PluginInstance.objects.get_or_create(
-            plugin=plugin, owner=user, compute_resource=plugin.compute_resources.all()[0])
-
-        # create mri_convert ds plugin instance
-        plugin = Plugin.objects.get(meta__name="mri_convert")
-        PluginInstance.objects.get_or_create(
-            plugin=plugin, owner=user, previous=self.pl_inst,
-            compute_resource=plugin.compute_resources.all()[0])
 
         self.read_update_delete_url = reverse("plugininstance-detail",
                                               kwargs={"pk": self.pl_inst.id})
@@ -419,10 +416,11 @@ class PluginInstanceDetailViewTests(TasksViewTests):
         # create a plugin's instance
         user = User.objects.get(username=self.username)
         (pl_inst, tf) = PluginInstance.objects.get_or_create(
-            plugin=plugin, owner=user, compute_resource=plugin.compute_resources.all()[0])
+            title='test2', plugin=plugin,
+            owner=user, compute_resource=plugin.compute_resources.all()[0])
         PathParameter.objects.get_or_create(plugin_inst=pl_inst, plugin_param=pl_param,
                                             value=user_space_path)
-        self.read_update_delete_url = reverse("plugininstance-detail",
+        read_update_delete_url = reverse("plugininstance-detail",
                                               kwargs={"pk": pl_inst.id})
 
         # run the plugin instance
@@ -431,7 +429,7 @@ class PluginInstanceDetailViewTests(TasksViewTests):
 
         # make API GET request
         self.client.login(username=self.username, password=self.password)
-        response = self.client.get(self.read_update_delete_url)
+        response = self.client.get(read_update_delete_url)
         self.assertContains(response, "simplefsapp")
         self.assertContains(response, 'started')
 
@@ -443,7 +441,7 @@ class PluginInstanceDetailViewTests(TasksViewTests):
         b_checkAgain = True
         time.sleep(10)
         while b_checkAgain:
-            response = self.client.get(self.read_update_delete_url)
+            response = self.client.get(read_update_delete_url)
             str_responseStatus = response.data['status']
             if str_responseStatus == 'finishedSuccessfully':
                 b_checkAgain = False
@@ -456,9 +454,9 @@ class PluginInstanceDetailViewTests(TasksViewTests):
 
         # delete files from swift storage
         self.swift_manager.delete_obj(user_space_path + 'test.txt')
-        obj_paths = self.swift_manager.ls(pl_inst.get_output_path())
-        for path in obj_paths:
-            self.swift_manager.delete_obj(path)
+        # obj_paths = self.swift_manager.ls(pl_inst.get_output_path())
+        # for path in obj_paths:
+        #     self.swift_manager.delete_obj(path)
 
     def test_plugin_instance_detail_failure_unauthenticated(self):
         response = self.client.get(self.read_update_delete_url)

--- a/make.sh
+++ b/make.sh
@@ -745,30 +745,26 @@ else
         cat dc.out | ./boxes.sh
    windowBottom
 
+    if (( ! b_skipIntegrationTests )) ; then
+        title -d 1 "Restarting the satellite services pfcon/pfioh/pman to clean their memory"
+            windowBottom
+            docker-compose --no-ansi -f docker-compose_dev.yml restart pman_service >& dc.out > /dev/null
+            docker-compose --no-ansi -f docker-compose_dev.yml restart pfioh_service >& dc.out > /dev/null
+            docker-compose --no-ansi -f docker-compose_dev.yml restart pfcon_service >& dc.out > /dev/null
+            echo -en "\033[2A\033[2K"
+            cat dc.out | ./boxes.sh
+        windowBottom
+    fi
+
     if (( !  b_norestartinteractive_chris_dev )) ; then
         title -d 1 "Restarting CUBE's Django development server"        \
                             "in interactive mode..."
-            printf "${LightCyan}%40s${LightGreen}%40s\n"                \
-                        "Stopping" "pman_service"                       | ./boxes.sh
-            windowBottom
-            docker-compose --no-ansi -f docker-compose_dev.yml stop pman_service >& dc.out > /dev/null
-            echo -en "\033[2A\033[2K"
-            cat dc.out | ./boxes.sh
-
-            printf "${LightCyan}%40s${LightGreen}%40s\n"                \
-                        "rm -f" "pman_service"                          | ./boxes.sh
-            windowBottom
-            docker-compose --no-ansi -f docker-compose_dev.yml rm -f pman_service >& dc.out > /dev/null
-            echo -en "\033[2A\033[2K"
-            cat dc.out | ./boxes.sh
-
             printf "${LightCyan}%40s${LightGreen}%40s\n"                \
                         "Stopping" "chris_dev"                          | ./boxes.sh
             windowBottom
             docker-compose --no-ansi -f docker-compose_dev.yml stop chris_dev >& dc.out >/dev/null
             echo -en "\033[2A\033[2K"
             cat dc.out | ./boxes.sh
-
 
             printf "${LightCyan}%40s${LightGreen}%40s\n"                \
                         "rm -f" "chris_dev"                             | ./boxes.sh


### PR DESCRIPTION
- Restart the satellite services after running integration tests to clean their memory
- Fix integration tests to not run the same job id twice