### PR TITLE
date --rfc-3339=s

### DIFF
--- a/decorate.sh
+++ b/decorate.sh
@@ -166,7 +166,7 @@ function title {
              {'printf("%*s%*s\n", 40+length($1)/2, $1, 41-length($1)/2, "");'})
     fi
     printf "\n"
-    DATE=" $(date) [$(hostname)] "
+    DATE=" $(date --rfc-3339=s) [$(hostname)] "
     lDATE=${#DATE}
     if (( b_date )) ; then
         printf "${NC}${White}"

--- a/make.sh
+++ b/make.sh
@@ -120,10 +120,6 @@
 #
 #
 
-# 24 hour time locale
-export LC_TIME=en_GB.utf-8  # or whatever you want
-export LC_ALL=$LC_TIME
-
 source ./decorate.sh
 source ./cparse.sh
 

--- a/plugin_add.sh
+++ b/plugin_add.sh
@@ -37,10 +37,6 @@
 #       JSON representation during the store registration phase.
 #
 
-# 24 hour time locale
-export LC_TIME=en_GB.utf-8  # or whatever you want
-export LC_ALL=$LC_TIME
-
 source ./decorate.sh
 source ./cparse.sh
 


### PR DESCRIPTION
### Before

```
Sat Oct 13 19:51:34 EDT 2020
```

Without (unnecessarily) having run `locale-gen` to include `en_GB.utf-8` you get many warnings

```
/bin/bash: warning: setlocale: LC_ALL: cannot change locale
```

# After

```
2020-10-13 19:51:34-04:00
```