### PR TITLE
Cparse using regex and docker inspect

### DIFF
--- a/cparse.sh
+++ b/cparse.sh
@@ -53,7 +53,7 @@
 # EXAMPLE
 #
 #       cparse fnndsc/pl-pfdicom_tagextract repo container mmn env
-#       echo "$repo $container $mmn $env"
+#       echo $repo $container $mmn $env
 #
 
 

--- a/cparse.sh
+++ b/cparse.sh
@@ -42,10 +42,8 @@
 #       the <container> part of the string.
 #
 # MMN
-#       if not passed, defaults to the <container> string
-#
-# EXT
-#       if not passed, defaults to empty.
+#       executable inside the container image, set by CMD inof Dockerfile.
+#       If image was not pulled, MMN will be "null"
 #
 # ENV
 #       if not passed, defaults to "host", else <env>.

--- a/cparse.sh
+++ b/cparse.sh
@@ -103,11 +103,15 @@ function cparse {
                 # the first `grep` selects the `"Config": {...}` object.
                 # the second `grep` selects the `"Cmd": [...]` array.
                 # finally, `cut` extracts the first string element of the array
+
                 str_mmn=$(echo $json | tr -d '\n' | grep -m 1 -o '"Config": {.*\}' \
                         | grep -m 1 -Po '(?<="Cmd": \[).+?(?=\])' | cut -d '"' -f2)
-                exit_code=$?
+                # cparse is also (mis-)used in make.sh to parse `A_CONTAINER`
+                # the services pman, pfioh, pfcon might not have CMD
+                # in this situation we should not fail the script,
+                # just return the string value "null" to match what `jq` would produce
                 if [ -z "$str_mmn" ]; then
-                        exit_code=1
+                        str_mmn=null
                 fi
         fi
 

--- a/make.sh
+++ b/make.sh
@@ -526,10 +526,10 @@ else
     ###
     STEP=$(expr $STEP + 1 )
     ./plugin_add.sh -s $STEP "\
-                        fnndsc/pl-simplefsapp%.py,                      \
-                        fnndsc/pl-simpledsapp%.py,                      \
-                        fnndsc/pl-s3retrieve%.py,                       \
-                        fnndsc/pl-dircopy%.py
+                        fnndsc/pl-simplefsapp,                      \
+                        fnndsc/pl-simpledsapp,                      \
+                        fnndsc/pl-s3retrieve,                       \
+                        fnndsc/pl-dircopy
     "
 
     STEP=$(expr $STEP + 4 )

--- a/plugin_add.sh
+++ b/plugin_add.sh
@@ -18,13 +18,13 @@
 # Notes on pluginList
 #
 # The plugin list is a comma separated list, each element conforming to a
-# cparse specification, i.e:
+# cparse specification, e.g.:
 #
-#           fnndsc/pl-pfdicom_tagextract::dcm_tagExtract%.py^moc
+#           fnndsc/pl-pfdicom_tagextract^moc
 #
 # templatized as:
 #
-#       [<repo>/]<container>[::<mainModuleName>[%<extension>[^<env>]]]
+#       [<repo>/]<container>[^<env>]
 #
 ##
 # ARGS
@@ -324,4 +324,3 @@ title -d 1 "Automatically registering some plugins from the ChRIS store" \
     fi
     echo ""                                                             | ./boxes.sh
     windowBottom
-

--- a/postscript.sh
+++ b/postscript.sh
@@ -12,24 +12,24 @@
 #
 
 ./plugin_add.sh  "\
-                    fnndsc/pl-dsdircopy%.py,                            \
-                    fnndsc/pl-simplefsapp%.py^moc,                      \
-                    fnndsc/pl-simpledsapp%.py^moc,                      \
-                    fnndsc/pl-s3push%.py,                               \
-                    fnndsc/pl-pfdicom_tagextract::dcm_tagExtract%.py,   \
-                    fnndsc/pl-pfdicom_tagsub::dcm_tagSub%.py,           \
-                    fnndsc/pl-mpcs%.py,                                 \
-                    fnndsc/pl-mpcs%.py^moc,                             \
-                    fnndsc/pl-fshack%.py,                               \
-                    fnndsc/pl-fastsurfer_inference%.py,                 \
-                    fnndsc/pl-freesurfer_pp%.py,                        \
-                    fnndsc/pl-freesurfer_pp%.py^moc,                    \
-                    fnndsc/pl-z2labelmap%.py,                           \
-                    fnndsc/pl-z2labelmap%.py^moc,                       \
-                    fnndsc/pl-mri10yr06mo01da_normal%.py,               \
-                    fnndsc/pl-mri10yr06mo01da_normal%.py^moc,           \
-                    fnndsc/pl-mgz2lut_report%.py,                       \
-                    fnndsc/pl-pfdo_mgz2img,                             \
+                    fnndsc/pl-dsdircopy,                            \
+                    fnndsc/pl-simplefsapp^moc,                      \
+                    fnndsc/pl-simpledsapp^moc,                      \
+                    fnndsc/pl-s3push,                               \
+                    fnndsc/pl-pfdicom_tagextract,                   \
+                    fnndsc/pl-pfdicom_tagsub,                       \
+                    fnndsc/pl-mpcs,                                 \
+                    fnndsc/pl-mpcs^moc,                             \
+                    fnndsc/pl-fshack,                               \
+                    fnndsc/pl-fastsurfer_inference,                 \
+                    fnndsc/pl-freesurfer_pp,                        \
+                    fnndsc/pl-freesurfer_pp^moc,                    \
+                    fnndsc/pl-z2labelmap,                           \
+                    fnndsc/pl-z2labelmap^moc,                       \
+                    fnndsc/pl-mri10yr06mo01da_normal,               \
+                    fnndsc/pl-mri10yr06mo01da_normal^moc,           \
+                    fnndsc/pl-mgz2lut_report,                       \
+                    fnndsc/pl-pfdo_mgz2img,                         \
                     fnndsc/pl-pfdo_med2img
 "
 


### PR DESCRIPTION
# Changes

- reimplement `cparse.sh` using regex (`grep` and [shell parameter expansion](https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html))
- `*.sh` dev environment suite of tools no longer depends on python! 
- delete `cparse_do` test function
- simplify "cparse" string plugin specification: `[repo/]container[^moc]`
  - update all usages of `plugin_add.sh`
- update docs

# Examples

```bash
$ source cparse.sh
$ cparse fnndsc/pl-pfdicom_tagextract repo container mmn env && echo $repo $container $mmn $env
fnndsc pl-pfdicom_tagextract dcm_tagExtract.py host
$ cparse 'fnndsc/pl-pfdicom_tagextract^moc' repo container mmn env && echo $repo $container $mmn $env
fnndsc pl-pfdicom_tagextract dcm_tagExtract.py moc
$ cparse fnndsc/pl-pfdo_med2img repo container mmn env && echo $repo $container $mmn $env
fnndsc pl-pfdo_med2img /usr/local/bin/pfdo_med2img host
$ cparse "fnndsc/pfcon:latest^PFCONREPO" repo container mmn env && echo $repo $container $mmn $env
fnndsc pfcon:latest null PFCONREPO
```

# Comments

It's an anti-pattern to automatically fill in a docker image tag without a repo as 'fnndsc/image'

If we were to change that, and with most of the "cstring" spec gutted, the remaining `^moc` spec is very unusual. I would suggest we refactor to work with container image tag names instead of custom "cstring pluginSpec".

The only valuable code remaining from `cparse.sh` would be

```bash
json=$(docker image inspect $1)

if which jq > /dev/null; then
        str_mmn=$(echo $json | jq -r '.[0].Config.Cmd[0]')
else
        str_mmn=$(echo $json | tr -d '\n' | grep -m 1 -o '"Config": {.*\}' \
                | grep -m 1 -Po '(?<="Cmd": \[).+?(?=\])' | cut -d '"' -f2)
fi
```