### PR TITLE
Use docker inspect --format

### DIFF
--- a/cparse.sh
+++ b/cparse.sh
@@ -93,13 +93,15 @@ function cparse {
         
         # cparse is also (mis-)used in make.sh to parse `A_CONTAINER`
         # the services pman, pfioh, pfcon might not have CMD
+        # so the else block sets str_mmn to "ERR_NO_CMD"
         local str_mmn=$(docker image inspect --format \
                 '{{with .Config.Cmd}}{{(index . 0)}}{{else}}ERR_NO_CMD{{end}}' \
                 "$str_repo/$str_container" 2> /dev/null)
 
         # in case docker insepct fails (like when image hasn't been pulled yet)
-        # set str_mmn to "null"
-        if [ "$?" -ne "0" ]; then
+        # an error is printed to stderr and a newline character is printed to stdout
+        # if $str_mmn is just whitespace, assume image hasn't been pulled yet
+        if [[ "$str_mmn" =~ ^[[:space:]]*$ ]]; then
                 str_mmn=ERR_IMAGE_NOT_PULLED
         fi
 

--- a/cparse.sh
+++ b/cparse.sh
@@ -90,31 +90,18 @@ function cparse {
         # note: instead of using what we were given, $str_dock,
         # we are rebuilding the string by concatention of its parts
         # because above we might have implicitly filled the repo as "fnndsc"
-        local json=$(docker image inspect "$str_repo/$str_container" 2> /dev/null)
-
-        if [ "$?" -eq "0" ]; then
-                # best way to inspect JSON is to use jq, of course.
-                # but we also provide a fallback using coreutils if jq is not installed
-                if which jq > /dev/null; then
-                        str_mmn=$(echo $json | jq -r '.[0].Config.Cmd[0]')
-                else
-                        # fallback strategy: use `tr` to join string on line breaks,
-                        # because grep operates per-line.
-                        # `grep` selects the `"Config": {...}` object.
-                        # `sed` selects the `"Cmd": [...]` array.
-                        # finally, `cut` extracts the first string element of the array.
-
-                        str_mmn=$(echo $json | tr -d '\n' | grep -m 1 -o '"Config": {.*\}' \
-                                | sed 's/"Config": {.*"Cmd": \[//' | cut -d '"' -f2)
-                fi
-        fi
+        
         # cparse is also (mis-)used in make.sh to parse `A_CONTAINER`
         # the services pman, pfioh, pfcon might not have CMD
-        # in this situation we should not fail the script,
-        # just return the string value "null" to match what `jq` would produce
-        
-        # str_mmn will be empty in case of any failures, like docker image was not pulled yet
-        str_mmn="${str_mmn:-null}"
+        local str_mmn=$(docker image inspect --format \
+                '{{with .Config.Cmd}}{{(index . 0)}}{{else}}ERR_NO_CMD{{end}}' \
+                "$str_repo/$str_container" 2> /dev/null)
+
+        # in case docker insepct fails (like when image hasn't been pulled yet)
+        # set str_mmn to "null"
+        if [ "$?" -ne "0" ]; then
+                str_mmn=ERR_IMAGE_NOT_PULLED
+        fi
 
         # register results into given variable names
         eval $__repo="'$str_repo'"


### PR DESCRIPTION
Didn't know this was a thing before. Better than `jq`, surely better than `grep | sed | cut`