### PR TITLE
Freeze pfurl==2.2.4.6

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,6 +8,6 @@ django-storage-swift==1.2.19
 celery==4.4.2
 django-celery-beat==2.0.0
 mod-wsgi==4.7.1
-pfurl>=2.2.2.2
+pfurl==2.2.4.6
 python-chrisstoreclient==1.0.0
 environs==7.4.0


### PR DESCRIPTION
pfurl>=2.3.0.0 deprecates `b_httpResponseBodyParse`, but it turns out this change was ahead of its time. See 
https://github.com/FNNDSC/pfurl/pull/39

The PR was not correct, `pfioh` is not the only service to return malformed HTTP headers -- `pfcon` is guilty as well.

ChRIS_ultron_backEnd's `pfurl>=2.2.2.2` requirement is too permissive

https://github.com/FNNDSC/ChRIS_ultron_backEnd/blob/45b9a29fe8305956ca5bf2aa6d977bae7584ec66/requirements/base.txt#L11