### PR TITLE
Foreign store url

### DIFF
--- a/chris_backend/plugins/services/manager.py
+++ b/chris_backend/plugins/services/manager.py
@@ -316,12 +316,14 @@ class PluginManager(object):
         """
         store_url = settings.CHRIS_STORE_URL
         store_client = StoreClient(store_url, None, None, timeout)
-        result = store_client.get_data_from_collection(store_client.get(url))
+        res = store_client.get(url)
+        result = store_client.get_data_from_collection(res)
         if result['data']:
             plg = result['data'][0]
+            parameters_url = res.items[0].links.get(rel='parameters').href
         else:
             raise NameError("Could not find plugin with url '%s'" % url)
-        plg['parameters'] = PluginManager.get_plugin_parameters_from_store(plg['id'],
+        plg['parameters'] = PluginManager.get_plugin_parameters_from_url(parameters_url,
                                                                            timeout)
         return plg
 
@@ -354,6 +356,24 @@ class PluginManager(object):
         while True:
             result = store_client.get_plugin_parameters(plg_id, {'limit': limit,
                                                                  'offset': offset})
+            parameters.extend(result['data'])
+            offset += limit
+            if not result['hasNextPage']: break
+        return parameters
+
+    @staticmethod
+    def get_plugin_parameters_from_url(parameters_url, timeout=30):
+        """
+        Get a plugin's parameters representation from a ChRIS store by URL.
+        """
+        store_url = settings.CHRIS_STORE_URL
+        store_client = StoreClient(store_url, None, None, timeout)
+        parameters = []
+        offset = 0
+        limit = 50
+        while True:
+            res = store_client.get(parameters_url, {'limit': limit, 'offset': offset})
+            result = store_client.get_data_from_collection(res)
             parameters.extend(result['data'])
             offset += limit
             if not result['hasNextPage']: break

--- a/chris_backend/plugins/services/manager.py
+++ b/chris_backend/plugins/services/manager.py
@@ -318,13 +318,13 @@ class PluginManager(object):
         store_client = StoreClient(store_url, None, None, timeout)
         res = store_client.get(url)
         result = store_client.get_data_from_collection(res)
-        if result['data']:
-            plg = result['data'][0]
-            parameters_url = res.items[0].links.get(rel='parameters').href
-        else:
-            raise NameError("Could not find plugin with url '%s'" % url)
-        plg['parameters'] = PluginManager.get_plugin_parameters_from_url(parameters_url,
-                                                                           timeout)
+
+        if 'data' not in result:
+            raise NameError(f"Could not find plugin with url '{url}'")
+
+        plg = result['data'][0]
+        parameters_url = res.items[0].links.get(rel='parameters').href
+        plg['parameters'] = PluginManager.get_plugin_parameters_from_url(parameters_url, timeout)
         return plg
 
     @staticmethod


### PR DESCRIPTION
# Bug

CUBE does not correctly add plugins by URL. In this situation, CUBE is being run with `CHRIS_STORE_URL=http://chrisstore.local:8010/api/v1/`

```
$ docker exec chris python plugins/services/manager.py register --pluginurl https://chrisstore.co/api/v1/plugins/20/ host
Traceback (most recent call last):
File "plugins/services/manager.py", line 366, in <module>
manager.run()
File "plugins/services/manager.py", line 260, in run
self.register_plugin_by_url(options.pluginurl, options.computeresource,
File "plugins/services/manager.py", line 149, in register_plugin_by_url
plg_repr = self.get_plugin_representation_from_store_by_url(url, timeout)
File "plugins/services/manager.py", line 324, in get_plugin_representation_from_store_by_url
plg['parameters'] = PluginManager.get_plugin_parameters_from_store(plg['id'],
File "plugins/services/manager.py", line 355, in get_plugin_parameters_from_store
result = store_client.get_plugin_parameters(plg_id, {'limit': limit,
File "/usr/local/lib/python3.8/dist-packages/chrisstoreclient/client.py", line 130, in get_plugin_parameters
raise StoreRequestException('Could not find plugin with id: %s.' % plugin_id)
chrisstoreclient.exceptions.StoreRequestException: Could not find plugin with id: 20.
```

https://github.com/FNNDSC/ChRIS_ultron_backEnd/blob/7205c8e805cb9e3699ec54bf1332e96b45b8e873/chris_backend/plugins/services/manager.py#L324

Meta is retrieved from `chrisstore.co` however there is no method to retrieve parameters data from the specified url. Instead CUBE tries to get the data from `chrisstore.local:8010` however the plugin does not exist there.

In another case where `chrisstore.local:8010` has more than 20 plugins, I predict that the operation would finish silently but with incorrect results.

# Fix

An implementation of [`get_plugin_parameters_from_store`](https://github.com/FNNDSC/ChRIS_ultron_backEnd/blob/7205c8e805cb9e3699ec54bf1332e96b45b8e873/chris_backend/plugins/services/manager.py#L345) is provided which uses a parameters url (e.g. `https://chrisstore.co/api/v1/plugins/20/parameters/`) instead of pluginId.

1. https://github.com/FNNDSC/ChRIS_ultron_backEnd/commit/cbd1b15d5c949bbbd9d375c8c18be70f72905aff is consistent with the current codebase's coding style.
2. https://github.com/FNNDSC/ChRIS_ultron_backEnd/commit/2e2429b2d7883c3984cf93e197773e9670dfc601 is a more opinionated approach but is functionally the same.

# Future Directions

[python-chrisstoreclient](https://github.com/FNNDSC/python-chrisstoreclient/) and [chris_backend/plugins/services/manager.py](https://github.com/FNNDSC/ChRIS_ultron_backEnd/blob/master/chris_backend/plugins/services/manager.py) should be refactored to improve on OOD and should provide a more unified API for getting plugin meta + details by pluginId v.s. pluginurl.