### PR TITLE
Allow chris-jid- to be configured

### DIFF
--- a/chris_backend/config/settings/local.py
+++ b/chris_backend/config/settings/local.py
@@ -95,6 +95,9 @@ except Exception as e:
 # ChRIS store settings
 CHRIS_STORE_URL = 'http://chris-store.local:8010/api/v1/'
 
+# ChRIS JID prefix used by pman's scheduler
+CHRIS_JID_PREFIX = 'chris-jid-'
+
 # Database
 # https://docs.djangoproject.com/en/2.2/ref/settings/#databases
 DATABASES['default']['NAME'] = 'chris_dev'

--- a/chris_backend/config/settings/production.py
+++ b/chris_backend/config/settings/production.py
@@ -70,6 +70,8 @@ except Exception as e:
 # CHRIS STORE SERVICE CONFIGURATION
 CHRIS_STORE_URL = get_secret('CHRIS_STORE_URL')
 
+# ChRIS JID prefix used by pman's scheduler
+CHRIS_JID_PREFIX = get_secret('CHRIS_JID_PREFIX')
 
 # LOGGING CONFIGURATION
 # See http://docs.djangoproject.com/en/2.2/topics/logging for

--- a/chris_backend/plugininstances/services/manager.py
+++ b/chris_backend/plugininstances/services/manager.py
@@ -77,7 +77,7 @@ class PluginInstanceManager(object):
         self.str_app_container_outputdir    = '/share/outgoing'
 
         # some schedulers require a minimum job ID string length
-        self.str_job_id = 'chris-jid-' + str(plugin_instance.id)
+        self.str_job_id = settings.CHRIS_JID_PREFIX + str(plugin_instance.id)
 
         # local data dir to store zip files before transmitting to the remote
         self.data_dir = os.path.join(os.path.expanduser("~"), 'data')


### PR DESCRIPTION
Production environment should define `CHRIS_JID_PREFIX`.

Perhaps this should be optional (and define a default `chris-jid-`)?