### PR TITLE
Support large arbitrary UID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ FROM fnndsc/ubuntu-python3:ubuntu20.04-python3.8.5
 MAINTAINER fnndsc "dev@babymri.org"
 
 # Pass a UID on build command line (see above) to set internal UID
-ARG UID=1001
+ARG UID=214748364
 ENV UID=$UID DEBIAN_FRONTEND=noninteractive VERSION="0.1"
 
 ENV APPROOT="/home/localuser/chris_backend" REQPATH="/usr/src/requirements"

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN apt-get update                                               \
   && apt-get install -y libssl-dev libmysqlclient-dev            \
   && apt-get install -y apache2 apache2-dev                      \
   && pip install -r ${REQPATH}/production.txt                    \
-  && useradd -u $UID -ms /bin/bash localuser
+  && useradd -l -u $UID -ms /bin/bash localuser
 
 # Start as user localuser
 USER localuser

--- a/Dockerfile_dev
+++ b/Dockerfile_dev
@@ -47,7 +47,7 @@ RUN apt-get update                                                \
   && pip install --upgrade pip                                    \
   && pip install -r ${REQPATH}/local.txt                          \
   && pip3 install https://github.com/msbrogli/rpudb/archive/master.zip \
-  && useradd -u $UID -ms /bin/bash localuser                      \
+  && useradd -l -u $UID -ms /bin/bash localuser                      \
   && echo "localuser ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 # Start as user localuser


### PR DESCRIPTION
Docker image size becomes unreasonably large with large UID because of a longstanding bug in the Go programming language.

https://github.com/moby/moby/issues/5419

Setting `UID=1001` is unsafe because it shadows users which already exist on the host system.