### PR TITLE
Add `delete_plugin_instance_job_from_remote` method

### DIFF
--- a/chris_backend/plugininstances/services/manager.py
+++ b/chris_backend/plugininstances/services/manager.py
@@ -551,7 +551,7 @@ class PluginInstanceManager(object):
                     self.c_plugin_inst.status = 'cancelled'  # giving up
                 else:
                     self.c_plugin_inst.status = 'finishedSuccessfully'
-                self.delete_plugin_instance_job_from_remote()
+            self.delete_plugin_instance_job_from_remote()
             self.save_plugin_instance_final_status()
 
     def _handle_finished_with_error_status(self):


### PR DESCRIPTION
- Fixes a bug in which a delete request could be sent from CUBE to pfcon twice for the same job.