### PR TITLE
Add functionality that deletes a job from the remote compute when the corresponding plugin instance is cancelled or deleted through the REST API

### DIFF
--- a/chris_backend/config/settings/local.py
+++ b/chris_backend/config/settings/local.py
@@ -71,7 +71,8 @@ LOGGING = {
 }
 
 for app in ['collectionjson', 'core', 'feeds', 'plugins', 'plugininstances', 'pipelines',
-            'pipelineinstances', 'uploadedfiles', 'pacsfiles', 'servicefiles', 'users']:
+            'pipelineinstances', 'uploadedfiles', 'pacsfiles', 'servicefiles', 'users',
+            'filebrowser']:
     LOGGING['loggers'][app] = {
             'level': 'DEBUG',
             'handlers': ['console_verbose', 'file'],

--- a/chris_backend/plugininstances/services/manager.py
+++ b/chris_backend/plugininstances/services/manager.py
@@ -202,7 +202,9 @@ class PluginInstanceManager(object):
         Cancel a plugin instance's app execution. It connects to the remote service
         to cancel job.
         """
-        pass
+        self.c_plugin_inst.status = 'cancelled'
+        self.delete_plugin_instance_job_from_remote()
+        self.save_plugin_instance_final_status()
 
     def delete_plugin_instance_job_from_remote(self):
         """

--- a/chris_backend/plugininstances/tests/test_tasks.py
+++ b/chris_backend/plugininstances/tests/test_tasks.py
@@ -76,6 +76,13 @@ class PluginInstanceTasksTests(TasksTests):
             tasks.check_plugin_instance_exec_status(self.plg_inst.id)
             check_exec_status_mock.assert_called_with()
 
+    def test_task_cancel_plugin_instance(self):
+        with mock.patch.object(tasks.PluginInstanceManager,
+                               'cancel_plugin_instance_app_exec',
+                               return_value=None) as cancel_mock:
+            tasks.cancel_plugin_instance(self.plg_inst.id)
+            cancel_mock.assert_called_with()
+
     def test_task_check_started_plugin_instances_exec_status(self):
         with mock.patch.object(tasks.check_plugin_instance_exec_status, 'delay',
                                return_value=None) as delay_mock:

--- a/chris_backend/plugininstances/views.py
+++ b/chris_backend/plugininstances/views.py
@@ -18,8 +18,7 @@ from .serializers import GenericParameterSerializer, PluginInstanceSplitSerializ
 from .serializers import PluginInstanceSerializer, PluginInstanceFileSerializer
 from .permissions import (IsRelatedFeedOwnerOrChris, IsOwnerOrChrisOrReadOnly,
                           IsOwnerOrReadOnly)
-from .tasks import (run_plugin_instance, check_plugin_instance_exec_status,
-                    cancel_plugin_instance)
+from .tasks import run_plugin_instance, cancel_plugin_instance
 
 
 class PluginInstanceList(generics.ListCreateAPIView):
@@ -217,7 +216,7 @@ class PluginInstanceDetail(generics.RetrieveUpdateDestroyAPIView):
         instance = self.get_object()
         descendants = instance.get_descendant_instances()
         if instance.status == 'started':
-            cancel_plugin_instance.delay(instance.id)  # call async task
+            cancel_plugin_instance(instance.id)
         for plg_inst in descendants:
             if plg_inst.status not in ('finishedSuccessfully', 'finishedWithError',
                                        'cancelled'):


### PR DESCRIPTION
Address #116.