### PR TITLE
Implemented mixins

### DIFF
--- a/chris_backend/pacsfiles/views.py
+++ b/chris_backend/pacsfiles/views.py
@@ -9,6 +9,7 @@ from core.renderers import BinaryFileRenderer
 from .models import PACSFile, PACSFileFilter
 from .serializers import PACSFileSerializer
 from .permissions import IsChrisOrReadOnly
+from uploadedfiles.views import ContentLengthMixin
 
 
 class PACSFileList(generics.ListCreateAPIView):
@@ -67,7 +68,7 @@ class PACSFileDetail(generics.RetrieveAPIView):
     permission_classes = (permissions.IsAuthenticated,)
 
 
-class PACSFileResource(generics.GenericAPIView):
+class PACSFileResource(ContentLengthMixin, generics.GenericAPIView):
     """
     A view to enable downloading of a file resource .
     """
@@ -75,10 +76,3 @@ class PACSFileResource(generics.GenericAPIView):
     queryset = PACSFile.objects.all()
     renderer_classes = (BinaryFileRenderer,)
     permission_classes = (permissions.IsAuthenticated,)
-
-    def get(self, request, *args, **kwargs):
-        """
-        Overriden to be able to make a GET request to an actual file resource.
-        """
-        pacs_file = self.get_object()
-        return FileResponse(pacs_file.fname)

--- a/chris_backend/plugininstances/views.py
+++ b/chris_backend/plugininstances/views.py
@@ -19,6 +19,7 @@ from .serializers import PluginInstanceSerializer, PluginInstanceFileSerializer
 from .permissions import (IsRelatedFeedOwnerOrChris, IsOwnerOrChrisOrReadOnly,
                           IsOwnerOrReadOnly)
 from .tasks import run_plugin_instance, cancel_plugin_instance
+from uploadedfiles.views import ContentLengthMixin 
 
 
 class PluginInstanceList(generics.ListCreateAPIView):
@@ -439,7 +440,7 @@ class PluginInstanceFileDetail(generics.RetrieveAPIView):
     permission_classes = (permissions.IsAuthenticated, IsRelatedFeedOwnerOrChris,)
 
 
-class FileResource(generics.GenericAPIView):
+class FileResource(ContentLengthMixin, generics.GenericAPIView):
     """
     A view to enable downloading of a file resource.
     """
@@ -448,12 +449,6 @@ class FileResource(generics.GenericAPIView):
     renderer_classes = (BinaryFileRenderer,)
     permission_classes = (permissions.IsAuthenticated, IsRelatedFeedOwnerOrChris,)
 
-    def get(self, request, *args, **kwargs):
-        """
-        Overriden to be able to make a GET request to an actual file resource.
-        """
-        plg_inst_file = self.get_object()
-        return FileResponse(plg_inst_file.fname)
 
 
 class PluginInstanceParameterList(generics.ListAPIView):

--- a/chris_backend/servicefiles/views.py
+++ b/chris_backend/servicefiles/views.py
@@ -9,6 +9,7 @@ from core.renderers import BinaryFileRenderer
 from .models import ServiceFile, ServiceFileFilter
 from .serializers import ServiceFileSerializer
 from .permissions import IsChrisOrReadOnly
+from uploadedfiles.views import ContentLengthMixin
 
 
 class ServiceFileList(generics.ListCreateAPIView):
@@ -62,7 +63,7 @@ class ServiceFileDetail(generics.RetrieveAPIView):
     permission_classes = (permissions.IsAuthenticated,)
 
 
-class ServiceFileResource(generics.GenericAPIView):
+class ServiceFileResource(ContentLengthMixin, generics.GenericAPIView):
     """
     A view to enable downloading of a file resource .
     """
@@ -71,9 +72,3 @@ class ServiceFileResource(generics.GenericAPIView):
     renderer_classes = (BinaryFileRenderer,)
     permission_classes = (permissions.IsAuthenticated,)
 
-    def get(self, request, *args, **kwargs):
-        """
-        Overriden to be able to make a GET request to an actual file resource.
-        """
-        service_file = self.get_object()
-        return FileResponse(service_file.fname)

--- a/chris_backend/uploadedfiles/views.py
+++ b/chris_backend/uploadedfiles/views.py
@@ -115,8 +115,21 @@ class UploadedFileDetail(generics.RetrieveUpdateDestroyAPIView):
         except Exception as e:
             logger.error('Swift storage error, detail: %s' % str(e))
 
+class ContentLengthMixin(object):
 
-class UploadedFileResource(generics.GenericAPIView):
+     def get(self, request, *args, **kwargs):
+        """
+        making GET request to the actual file resource
+        """
+        file = self.get_object()
+        response = FileResponse(file.fname)
+        response['Content-Length'] = file.fname.size
+        return response
+
+
+    
+
+class UploadedFileResource(ContentLengthMixin, generics.GenericAPIView):
     """
     A view to enable downloading of a file resource .
     """
@@ -125,11 +138,4 @@ class UploadedFileResource(generics.GenericAPIView):
     renderer_classes = (BinaryFileRenderer,)
     permission_classes = (permissions.IsAuthenticated, IsOwnerOrChris)
 
-    def get(self, request, *args, **kwargs):
-        """
-        Overriden to be able to make a GET request to an actual file resource.
-        """
-        user_file = self.get_object()
-        response = FileResponse(user_file.fname)
-        response["Content-Length"] = len(user_file.fname)
-        return response
+   

--- a/chris_backend/uploadedfiles/views.py
+++ b/chris_backend/uploadedfiles/views.py
@@ -130,4 +130,6 @@ class UploadedFileResource(generics.GenericAPIView):
         Overriden to be able to make a GET request to an actual file resource.
         """
         user_file = self.get_object()
-        return FileResponse(user_file.fname)
+        response = FileResponse(user_file.fname)
+        response["Content-Length"] = len(user_file.fname)
+        return response


### PR DESCRIPTION
This fixes #381

added mixins to implement , 'Content-Length' in the response header on all the routes , which serve a FileResponse.

**Screenshots** 

![Screenshot_2022-05-09_12-32-05](https://user-images.githubusercontent.com/90280586/167357394-640f4ec0-7203-4616-8328-f02270e2408b.png)

