### PR TITLE
Fixed #392 CUBE kubernetes environment failed to start.

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -431,9 +431,7 @@ rm -f dc.out ; title -d 1 "Waiting for remote pfcon containers to start running 
         if [[ $ORCHESTRATOR == swarm ]]; then
             pfcon=$(docker ps -f name=pfcon_stack_pfcon.1 -q)
         elif [[ $ORCHESTRATOR == kubernetes ]]; then
-            pfcon=$(kubectl get pods --selector="app=pfcon,env=production"     \
-                        --field-selector=status.phase=Running --               \
-                        output=jsonpath='{.items[*].metadata.name}')
+            pfcon=$(kubectl get pods --selector="app=pfcon,env=production" | awk '{print$1}' | head -2)
         fi
         if [ -n "$pfcon" ]; then
           echo -en "\033[3A\033[2K"


### PR DESCRIPTION
This Fixes #392 

We were trying to extract name of the pfcon pod in make.sh (Line no. 434),
using awk fixed the issue

```
┌─────────────────────────────────────────────────────────┐
│ Wed, 18 May 2022 19:21:09 +0530 [prakash-gf63thin9scsr] │
├─────────────────────────────────────────────────────────┴──────────────────────┐
│          7: Waiting for remote pfcon containers to start running on            │▒
│                               -= kubernetes =-                                 │▒
├────────────────────────────────────────────────────────────────────────────────┤▒
│                                                                                │▒
│               Success: pfcon container is running on kubernetes                │▒
│                                                                                │▒
└────────────────────────────────────────────────────────────────────────────────┘▒
 ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
