### PR TITLE
Check whether default is given

### DIFF
--- a/chris_backend/workflows/serializers.py
+++ b/chris_backend/workflows/serializers.py
@@ -146,8 +146,13 @@ class WorkflowSerializer(serializers.HyperlinkedModelSerializer):
                 [f"Can not run workflow. Parameter "
                  f"'{default_param.plugin_param.name}' for piping with id "
                  f"{piping_id} does not have a default value in the pipeline"])
-        if l and l[0].get('default'):
+        if l:
             param_default = l[0].get('default')
+            if not param_default:
+                raise serializers.ValidationError(
+                    f"\"default\" not provided for parameter \"{default_param.plugin_param.name}\" "
+                    f"of piping_id={piping_id}"
+                )
             param_type = default_param.plugin_param.type
             default_serializer_cls = DEFAULT_PIPING_PARAMETER_SERIALIZERS[param_type]
             default_serializer = default_serializer_cls(data={'value': param_default})

--- a/chris_backend/workflows/tests/test_serializers.py
+++ b/chris_backend/workflows/tests/test_serializers.py
@@ -187,6 +187,11 @@ class WorkflowSerializerTests(SerializerTests):
                              "plugin_parameter_defaults": [{"name": "dummyInt", "default": "badInt"}]},
                             {"piping_id": self.pips[1].id,"compute_resource_name": "host"}])
             )
+        with self.assertRaises(serializers.ValidationError) as e:
+            workflow_serializer.validate_nodes_info(
+                json.dumps([{"piping_id": self.pips[0].id,
+                             "plugin_parameter_defaults": [{"name": "dummyInt"}]}])
+            )
 
     def test_validate_canonicalizes(self):
         pipeline = Pipeline.objects.get(name=self.pipeline_name)


### PR DESCRIPTION
Elements of `plugin_parameter_defaults` from a POST request to create a workflow is not being validated correctly. This PR fixes the validation, ensuring that for parameters which are mentioned in `plugin_parameter_defaults`, a value for `default` must also be given.