### PR TITLE
Fixed CUBE minikube backend deployment

### DIFF
--- a/docker-compose_dev.yml
+++ b/docker-compose_dev.yml
@@ -45,7 +45,7 @@ services:
     command: python manage.py runserver 0.0.0.0:8000
     ports:
       - "8000:8000"
-    depends_on:
+    depends_on: 
       - chris_dev_db
       - swift_service
       - queue
@@ -55,6 +55,7 @@ services:
         aliases:
           - chrisdev.local
       remote:  # bc special automated tests worker runs within CUBE, not needed in prod
+      minikube: 
     extra_hosts:
       - "${PFCONDNS:-lhost}:${PFCONIP:-127.0.0.1}"  # used only for kubernetes, not needed in prod
     labels:
@@ -92,6 +93,10 @@ services:
     # instead use extra_hosts to let the worker know pfcon's IP address. The required
     # shell variables referenced here must then be set like this: PFCONDNS=pfcon.remote,
     # PFCONIP=<actual IP address of localhost> and REMOTENETWORK=false
+
+    # if you are using minikube to run the kubernetes cluster, Set the environment variable in make.sh
+    # MINIKUBENETWORK to true and the HOSTIP will be minikube's ip, to get this, you can run the 
+    # command 'minikube ip' on the terminal
     extra_hosts:
       - "${PFCONDNS:-lhost}:${PFCONIP:-127.0.0.1}"
     labels:
@@ -239,6 +244,8 @@ networks:
   local:
   remote:
     external: ${REMOTENETWORK:-true}
+  minikube:
+    external: ${MINIKUBENETWORK:-true}
 
 volumes:
   chris_dev_db_data:

--- a/kubernetes/remote.yaml
+++ b/kubernetes/remote.yaml
@@ -121,3 +121,38 @@ spec:
               value: ${STOREBASE}
             - name: CONTAINER_ENV
               value: kubernetes
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: job-creator
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: default
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: default
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: default
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: default
+  namespace: default
+rules:
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+

--- a/make.sh
+++ b/make.sh
@@ -245,7 +245,9 @@ shift $(($OPTIND - 1))
 if [[ $ORCHESTRATOR == kubernetes ]]; then
     if [ -z ${HOSTIP+x} ]; then
         echo "-P <hostIp> (this machine's ip address) must be specified or the shell
-             environment variable HOSTIP must be set when using kubernetes orchestrator"
+             environment variable HOSTIP must be set when using kubernetes orchestrator
+             If you are using minikube to run the development environment, HOSTIP can be gotten by running
+             'minikube ip' on the terminal"
         print_usage
     fi
 fi
@@ -275,6 +277,8 @@ rm -f dc.out ; title -d 1 "Setting global exports"
         echo -e "HOSTIP=$HOSTIP"                   | ./boxes.sh
         echo -e "exporting REMOTENETWORK=false "   | ./boxes.sh
         export REMOTENETWORK=false
+        echo -e "exporting MINIKUBENETWORK=true"
+        export MINIKUBENETWORK=true
         echo -e "exporting PFCONDNS=pfcon.remote " | ./boxes.sh
         export PFCONDNS=pfcon.remote
         boxcenter "exporting PFCONIP=$HOSTIP "


### PR DESCRIPTION
Fixes #396 

The issue raised which showed 'connection refused' was because the chris_dev remote container and pfcon Kubernetes pod were in different networks. I solved this issue by adding minikube as an external network in the docker-compose file, and the only way communication could be ensured was using minikube's external IP as the HOSTIP. Note: This was only tested with minikube having a docker driver, with other drivers such as hyperkit, the outcome is not ensured.

A second issue after going past this was the error when the job(zip file) was supposed to be submitted from pfcon to pman. These caused tests in the ./make.sh bash script to fail. This issue was fixed by attaching a role and binding the role to the default ServiceAccount in the default Namespace. This issue doesn't exist in the prod setup because of the availability of these configurations. But it is helpful for those running the development setup.

Before:
![unnamed](https://user-images.githubusercontent.com/47697463/195989321-1caa72e8-7a82-4e1e-81bb-9d146e54abbc.png)

After:

![unnamed](https://user-images.githubusercontent.com/47697463/195989348-a7beb182-c8a3-4d15-ba12-49b3c575d7bf.png)
