### PR TITLE
Unauthenticated user acess to /api/v1/plugins and /api/v1/pipelines APIs

### DIFF
--- a/chris_backend/pipelines/models.py
+++ b/chris_backend/pipelines/models.py
@@ -4,6 +4,7 @@ from django.core.exceptions import ObjectDoesNotExist
 
 import django_filters
 from django_filters.rest_framework import FilterSet
+from rest_framework import  permissions
 
 from plugins.models import Plugin, PluginParameter
 
@@ -80,7 +81,7 @@ class Pipeline(models.Model):
         """
         queryset = Pipeline.objects.all()
         # if the user is chris then return all the pipelines in the queryset
-        if user.username == 'chris':
+        if user.username == 'chris' or not user.is_authenticated:
             return queryset
         # construct the full lookup expression.
         lookup = models.Q(locked=False) | models.Q(owner=user)

--- a/chris_backend/pipelines/tests/test_views.py
+++ b/chris_backend/pipelines/tests/test_views.py
@@ -130,7 +130,6 @@ class PipelineListViewTests(PipelineViewTests):
 
     def test_pipeline_list_failure_unauthenticated(self):
         response = self.client.get(self.create_read_url)
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
 
 class PipelineListQuerySearchViewTests(PipelineViewTests):

--- a/chris_backend/pipelines/views.py
+++ b/chris_backend/pipelines/views.py
@@ -21,7 +21,7 @@ class PipelineList(generics.ListCreateAPIView):
     """
     http_method_names = ['get', 'post']
     serializer_class = PipelineSerializer
-    permission_classes = (permissions.IsAuthenticated,)
+    permission_classes = (permissions.IsAuthenticatedOrReadOnly,)
 
     def get_queryset(self):
         """

--- a/chris_backend/plugins/tests/test_views.py
+++ b/chris_backend/plugins/tests/test_views.py
@@ -214,7 +214,6 @@ class PluginListViewTests(ViewTests):
 
     def test_plugin_list_failure_unauthenticated(self):
         response = self.client.get(self.list_url)
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
 
 class PluginListQuerySearchViewTests(ViewTests):

--- a/chris_backend/plugins/views.py
+++ b/chris_backend/plugins/views.py
@@ -135,7 +135,7 @@ class PluginList(generics.ListAPIView):
     http_method_names = ['get']
     serializer_class = PluginSerializer
     queryset = Plugin.objects.all()
-    permission_classes = (permissions.IsAuthenticated,)
+    permission_classes = (permissions.IsAuthenticatedOrReadOnly,)
 
     def list(self, request, *args, **kwargs):
         """


### PR DESCRIPTION
## Made Global API available to anonymous users
Previously ChRIS_ultron_backend used to serve api to authenticated and authorized users only. But Global API /api/v1/plugins and /api/v1/pipelines can be exposed to unauthenticated users as read only. This code changes should close #452  issue