### PR TITLE
Implement canonical pipeline representations using titles

### DIFF
--- a/chris_backend/pipelines/tests/test_manager.py
+++ b/chris_backend/pipelines/tests/test_manager.py
@@ -72,9 +72,9 @@ class PipelineManagerTests(TestCase):
         Test whether the manager can add a new pipeline to the system.
         """
         plugin_tree = '[{"title": "pip3", "plugin_name": "simpledsapp", ' \
-                      '"plugin_version": "0.1", "previous_index": null},  {"title": ' \
+                      '"plugin_version": "0.1", "previous": null},  {"title": ' \
                       '"pip4", "plugin_name": "simpledsapp", "plugin_version": "0.1",  ' \
-                      '"previous_index": 0}]'
+                      '"previous": "pip3"}]'
         self.pipeline_manager.run(['add', 'Pipeline2', self.username, plugin_tree, '--unlock'])
         self.assertEqual(Pipeline.objects.count(), 2)
 

--- a/chris_backend/pipelines/tests/test_views.py
+++ b/chris_backend/pipelines/tests/test_views.py
@@ -131,8 +131,8 @@ class PipelineListViewTests(PipelineViewTests):
         plugin_ds2.save()
 
         plugin_tree = '[{"title": "pip5", "plugin_id": ' + str(plugin_ds1.id) + \
-                      ', "previous_index": null}, {"title": "pip6", "plugin_id": ' + \
-                      str(plugin_ds2.id) + ', "previous_index": 0}]'
+                      ', "previous": null}, {"title": "pip6", "plugin_id": ' + \
+                      str(plugin_ds2.id) + ', "previous": "pip5"}]'
         post = json.dumps(
             {"template": {"data": [{"name": "name", "value": "Pipeline2"},
                                    {"name": "plugin_tree", "value": plugin_tree}]}})
@@ -251,12 +251,12 @@ class PipelineCustomJsonDetailViewTests(PipelineViewTests):
         pipeline = Pipeline.objects.get(name="Pipeline1")
         self.read_url = reverse("pipeline-detail", kwargs={"pk": pipeline.id})
 
-    def test_pipeline_detail_success(self):
+    def test_pipeline_json_detail_success(self):
         owner = User.objects.get(username=self.username)
         # create a pipeline
         (pipeline_ts, tf) = Pipeline.objects.get_or_create(name='Pipeline_ts',
                                                         owner=owner, category='test')
-        plugin_ds1 = Plugin.objects.get(meta__name=self.plugin_ds_name)
+        plugin_ds = Plugin.objects.get(meta__name=self.plugin_ds_name)
 
         (pl_meta, tf) = PluginMeta.objects.get_or_create(name='ts_mycopy', type='ts')
         (plugin_ts, tf) = Plugin.objects.get_or_create(meta=pl_meta, version='0.1')
@@ -274,10 +274,10 @@ class PipelineCustomJsonDetailViewTests(PipelineViewTests):
 
         # create plugin pipings
         (pip_ds1, tf) = PluginPiping.objects.get_or_create(title='pip1',
-                                                           plugin=plugin_ds1,
+                                                           plugin=plugin_ds,
                                                            pipeline=pipeline_ts)
         (pip_ds2, tf) = PluginPiping.objects.get_or_create(title='pip2',
-                                                           plugin=plugin_ds1,
+                                                           plugin=plugin_ds,
                                                            previous=pip_ds1,
                                                            pipeline=pipeline_ts)
         (pip_ts, tf) = PluginPiping.objects.get_or_create(title='pip3',
@@ -294,7 +294,7 @@ class PipelineCustomJsonDetailViewTests(PipelineViewTests):
         response = self.client.get(read_url)
         self.assertContains(response, "Pipeline_ts")
         self.assertContains(response, "plugininstances")
-        self.assertContains(response, "0,")  # could be "0,1" or "0,2"
+        self.assertContains(response, "pip1")
 
     def test_pipeline_detail_locked_failure_unauthenticated(self):
         response = self.client.get(self.read_url)
@@ -323,7 +323,7 @@ class PipelineSourceFileViewTests(PipelineViewTests):
           plugin: ts_copy v0.1
           previous: simpledsapp1
           plugin_parameter_defaults:
-            plugininstances: simpledsapp1, simpledsapp2
+            plugininstances: simpledsapp1,simpledsapp2
         """
 
     def tearDown(self):

--- a/chris_backend/pipelines/views.py
+++ b/chris_backend/pipelines/views.py
@@ -103,9 +103,12 @@ class PipelineDetail(generics.RetrieveUpdateDestroyAPIView):
 
     def update(self, request, *args, **kwargs):
         """
-        Overriden to include required parameters if not in the request and delete
-        'locked' parameter if the pipeline is not locked.
+        Overriden to remove parameters that are not allowed to be used on update,
+        include required parameters if not in the request and delete 'locked' parameter
+        if the pipeline is not locked.
         """
+        request.data.pop('plugin_tree', None)
+        request.data.pop('plugin_inst_id', None)
         pipeline = self.get_object()
         if not pipeline.locked and 'locked' in request.data:
             # this pipeline was made available to the public so it cannot be locked

--- a/make.sh
+++ b/make.sh
@@ -560,9 +560,9 @@ rm -f dc.out ; title -d 1 "Automatically creating two unlocked pipelines in the 
     STR1='[{"title": "pl-s3retrieve", "plugin_name": "pl-s3retrieve", "plugin_version": "'
     STR2='", "plugin_parameter_defaults": [{"name": "bucket", "default": "somebucket"},
       {"name": "awssecretkey", "default": "somekey"},
-    {"name": "awskeyid", "default": "somekeyid"}], "previous_index": null},  {"title":
+    {"name": "awskeyid", "default": "somekeyid"}], "previous_index": null, "previous": null},  {"title":
     "pl-simpledsapp", "plugin_name": "pl-simpledsapp", "plugin_version": "'
-    STR3='", "previous_index": 0}]'
+    STR3='", "previous_index": 0, "previous": "pl-s3retrieve"}]'
     PLUGIN_TREE=${STR1}${S3_PLUGIN_VER}${STR2}${SIMPLEDS_PLUGIN_VER}${STR3}
     windowBottom
     docker compose -f docker-compose_dev.yml                        \
@@ -574,11 +574,11 @@ rm -f dc.out ; title -d 1 "Automatically creating two unlocked pipelines in the 
     printf "%20s${LightBlue}%60s${NC}\n"                            \
                 "Creating pipeline..." "[ $PIPELINE_NAME ]"         | ./boxes.sh
     STR4='[{"title": "pl-simpledsapp1", "plugin_name": "pl-simpledsapp", "plugin_version": "'
-    STR5='", "previous_index": null},{"title": "pl-simpledsapp2", "plugin_name":
+    STR5='", "previous_index": null, "previous": null},{"title": "pl-simpledsapp2", "plugin_name":
     "pl-simpledsapp", "plugin_version": "'
-    STR6='", "previous_index": 0},{"title": "pl-simpledsapp3", "plugin_name":
+    STR6='", "previous_index": 0, "previous": "pl-simpledsapp1"},{"title": "pl-simpledsapp3", "plugin_name":
     "pl-simpledsapp", "plugin_version": "'
-    STR7='", "previous_index": 0}]'
+    STR7='", "previous_index": 0, "previous": "pl-simpledsapp1"}]'
     PLUGIN_TREE=${STR4}${SIMPLEDS_PLUGIN_VER}${STR5}${SIMPLEDS_PLUGIN_VER}${STR6}${SIMPLEDS_PLUGIN_VER}${STR7}
     windowBottom
     docker compose -f docker-compose_dev.yml                        \
@@ -614,20 +614,6 @@ rm -f dc.out ; title -d 1 "Automatically creating an unlocked pipeline in CUBE" 
         cube "${PLUGIN_TREE}" --unlock >& dc.out
     dc_check $? "PRINT"
 windowBottom
-
-# rm -f dc.out ; title -d 1 "Automatically creating an unlocked pipeline in CUBE"    \
-#                 "(unmutable and available to all users)"
-#     PIPELINE_NAME="DICOM_anonymization_and_tag_extractor"
-#     printf "%20s${LightBlue}%60s${NC}\n"                            \
-#                 "Creating pipeline..." "[ $PIPELINE_NAME ]"         | ./boxes.sh
-#     PLUGIN_TREE="[\n                {\n                    \"plugin_name\":      \"pl-simpledsapp\",\n                    \"plugin_version\":   \"2.0.2\",\n                    \"previous_index\":   null\n                },\n                {\n                    \"plugin_name\":      \"pl-pfdicom_tagextract\",\n                    \"plugin_version\":   \"3.1.2\",\n                    \"previous_index\":   0,\n                    \"plugin_parameter_defaults\": [\n                            {\n                            \"name\":     \"extension\",\n                            \"default\":  \".dcm\"\n                            },\n                            {\n                            \"name\":     \"imageFile\",\n                            \"default\":  \"m:%_nospc|-_ProtocolName.jpg\"\n                            },\n                            {\n                            \"name\":     \"imageScale\",\n                            \"default\":  \"3:none\"\n                            },\n                            {\n                            \"name\":     \"outputFileStem\",\n                            \"default\":  \"PHI-tags\"\n                            }\n                        ]\n                },\n                {\n                    \"plugin_name\":      \"pl-pfdicom_tagsub\",\n                    \"plugin_version\":   \"3.2.3\",\n                    \"previous_index\":   0,\n                    \"plugin_parameter_defaults\": [\n                            {\n                            \"name\":     \"extension\",\n                            \"default\":  \".dcm\"\n                            },\n                            {\n                            \"name\":     \"tagInfo\",\n                            \"default\":  \"PatientName,%_name|patientID_PatientName ++ PatientID,%_md5|7_PatientID ++ AccessionNumber,%_md5|8_AccessionNumber ++ PatientBirthDate,%_strmsk|******01_PatientBirthDate ++ re:.*hysician,%_md5|4_#tag ++ re:.*stitution,#tag ++ re:.*ddress,#tag\"\n                            },\n                            {\n                            \"name\":     \"splitKeyValue\",\n                            \"default\":  \",\"\n                            },\n                            {\n                            \"name\":     \"splitToken\",\n                            \"default\":  \"++\"\n                            }\n                        ]\n                },\n                {\n                    \"plugin_name\":      \"pl-pfdicom_tagextract\",\n                    \"plugin_version\":   \"3.1.2\",\n                    \"previous_index\":   2,\n                    \"plugin_parameter_defaults\": [\n                            {\n                            \"name\":     \"extension\",\n                            \"default\":  \".dcm\"\n                            },\n                            {\n                            \"name\":     \"imageFile\"]"
-#     windowBottom
-#     docker compose -f docker-compose_dev.yml                        \
-#         exec chris_dev                                              \
-#         python pipelines/services/manager.py add "${PIPELINE_NAME}" \
-#         cube "${PLUGIN_TREE}" --unlock >& dc.out
-#     dc_check $? "PRINT"
-# windowBottom
 
 rm -f dc.out ; title -d 1 "Restarting CUBE's Django development server"
     printf "${LightCyan}%40s${LightGreen}%40s\n"                \


### PR DESCRIPTION
Implement canonical pipeline representations using titles. **Breaking change**: The `previous_index` attribute in `plugin_tree` has been changed to `previous`.