### PR TITLE
Update superuser password if already exists

### DIFF
--- a/chris_backend/core/apps.py
+++ b/chris_backend/core/apps.py
@@ -13,6 +13,8 @@ def setup_chris(sender, **kwargs):
     # create superuser chris
     try:
         chris_user = User.objects.get(username='chris')
+        chris_user.set_password(settings.CHRIS_SUPERUSER_PASSWORD)
+        chris_user.save()
     except User.DoesNotExist:
         chris_user = User.objects.create_superuser('chris', 'dev@babymri.org',
                                                    settings.CHRIS_SUPERUSER_PASSWORD)


### PR DESCRIPTION
If the superuser already exists, its password will be set to the value of the `CHRIS_SUPERUSER_PASSWORD` environment variable. This way, the superuser's password can be easily changed by restarting CUBE, and CUBE's state will match the environment variables when the environment variables are changed.