### PR TITLE
Fix all spectacular warnings and add OpenAPI spec to release draft

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
           command: test-${{ matrix.test-kind }}
 
   build:
+    name: Build
     needs: [ test ]
     if: github.event_name == 'push'
     runs-on: ubuntu-24.04
@@ -63,7 +64,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -84,3 +85,63 @@ jobs:
           short-description: ChRIS backend
           readme-filepath: ./README.md
           repository: fnndsc/cube
+
+  openapi:
+    name: Generate OpenAPI Schema
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: taiki-e/install-action@just
+      - uses: actions/checkout@v4
+      - name: Generate OpenAPI schema (correct)
+        run: just openapi 2> spectacular.log > schema.yaml
+      - name: Generate OpenAPI schema (split)
+        run: just openapi-split 2> spectacular_split.log > schema_split.yaml
+      - name: Upload schema YAML files
+        uses: actions/upload-artifact@v4
+        with:
+          name: openapi_schema
+          path: schema*.yaml
+          if-no-files-found: error
+      - name: Assert no drf-spectacular errors nor warnings
+        run: |
+          for f in spectacular*.log; do
+            if grep -qi '(warning|error)' $f;
+              cat $f
+              exit 1
+            fi
+          done
+
+  draft-release:
+    name: Draft GitHub Release
+    runs-on: ubuntu-24.04
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs:
+      - build
+      - openapi
+    steps:
+      - id: version
+        run: echo "version=${GITHUB_REF_NAME:1}" >> "$GITHUB_OUTPUT"
+      - uses: actions/download-artifact@v4
+        with:
+          name: openapi_schema
+      - uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          prerelease: ${{ contains( github.ref_name, '-' ) }}
+          files: openapi_schema/*.yaml
+          fail_on_unmatched_files: true
+          name: CUBE - version ${{ steps.version.outputs.version }}
+          generate_release_notes: true
+          body: |
+            ## Getting the Image
+            
+            Using [Podman](https://podman.io):
+            
+            ```shell
+            podman pull ghcr.io/fnndsc/cube:${{ steps.version.outputs.version }}
+            ```
+            Using [Docker](https://docker.com):
+            
+            ```shell
+            docker pull ghcr.io/fnndsc/cube:${{ steps.version.outputs.version }}
+            ```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
     steps:
       - uses: taiki-e/install-action@just
       - uses: actions/checkout@v4
+      - run: just prefer docker
       - name: Generate OpenAPI schema (correct)
         run: just openapi 2> spectacular.log > schema.yaml || (cat spectacular.log; exit 1)
       - name: Generate OpenAPI schema (split)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Assert no drf-spectacular errors nor warnings
         run: |
           for f in spectacular*.log; do
-            if grep -qi '(warning|error)' $f;
+            if grep -qi '(warning|error)' $f; then
               cat $f
               exit 1
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,9 +93,9 @@ jobs:
       - uses: taiki-e/install-action@just
       - uses: actions/checkout@v4
       - name: Generate OpenAPI schema (correct)
-        run: just openapi 2> spectacular.log > schema.yaml
+        run: just openapi 2> spectacular.log > schema.yaml || (cat spectacular.log; exit 1)
       - name: Generate OpenAPI schema (split)
-        run: just openapi-split 2> spectacular_split.log > schema_split.yaml
+        run: just openapi-split 2> spectacular_split.log > schema_split.yaml || (cat spectacular_split.log; exit 1)
       - name: Upload schema YAML files
         uses: actions/upload-artifact@v4
         with:
@@ -110,6 +110,8 @@ jobs:
               exit 1
             fi
           done
+      - name: Clean up
+        run: just nuke
 
   draft-release:
     name: Draft GitHub Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,8 +112,8 @@ jobs:
               exit 1
             fi
           done
-      - name: Clean up
-        run: just nuke
+      - name: Stop services
+        run: just down
 
   draft-release:
     name: Draft GitHub Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,7 @@ jobs:
       - uses: taiki-e/install-action@just
       - uses: actions/checkout@v4
       - run: just prefer docker
+      - run: just build
       - name: Generate OpenAPI schema (correct)
         run: just openapi 2> spectacular.log > schema.yaml || (cat spectacular.log; exit 1)
       - name: Generate OpenAPI schema (split)

--- a/chris_backend/config/settings/common.py
+++ b/chris_backend/config/settings/common.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from environs import Env
 
 from __version__ import __version__
+from plugins.enums import PLUGIN_TYPE_CHOICES, TYPE_CHOICES
 
 # Environment variables-based secrets
 env = Env()
@@ -196,6 +197,10 @@ SPECTACULAR_SETTINGS = {
         'email': 'dev@babymri.org'
     },
     'SERVE_INCLUDE_SCHEMA': True,
+    'ENUM_NAME_OVERRIDES': {
+        'PluginType': PLUGIN_TYPE_CHOICES,
+        'PluginParameterType': TYPE_CHOICES,
+    },
     'COMPONENT_SPLIT_REQUEST': env.bool("SPECTACULAR_SPLIT_REQUEST", False),
     'PREPROCESSING_HOOKS': [
         'drf_spectacular.hooks.preprocess_exclude_path_format',
@@ -203,7 +208,7 @@ SPECTACULAR_SETTINGS = {
     'POSTPROCESSING_HOOKS': [
         'drf_spectacular.hooks.postprocess_schema_enums',
         'collectionjson.spectacular_hooks.postprocess_remove_collectionjson',
-        'plugininstances.spectacular_hooks.additionalproperties_for_plugins_instances_create'
+        'plugininstances.spectacular_hooks.additionalproperties_for_plugins_instances_create',
     ],
 
     'SCHEMA_PATH_PREFIX': '/api/v1/',

--- a/chris_backend/core/serializers.py
+++ b/chris_backend/core/serializers.py
@@ -1,11 +1,14 @@
+from typing import Optional
 
 from rest_framework import serializers
+from drf_spectacular.utils import OpenApiTypes, extend_schema_field
 
+from collectionjson.fields import ItemLinkField
+from .utils import get_file_resource_link
 from .models import ChrisInstance, FileDownloadToken
 
 
 class ChrisInstanceSerializer(serializers.HyperlinkedModelSerializer):
-
     class Meta:
         model = ChrisInstance
         fields = ('url', 'id', 'creation_date', 'name', 'uuid', 'job_id_prefix',
@@ -20,3 +23,48 @@ class FileDownloadTokenSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = FileDownloadToken
         fields = ('url', 'id', 'creation_date', 'token', 'owner_username', 'owner')
+
+
+def file_serializer(cls: Optional[serializers.SerializerMetaclass] = None, required: bool = True):
+    """
+    A class decorator for adding fields to serializers of ``ChrisFile`` views.
+
+    :param cls: the serializer to wrap
+    :param required: whether the ``fname`` field is required
+    """
+    if cls is None:
+        return lambda cls: _wrap_file_serializer_class(cls, required)
+    return _wrap_file_serializer_class(cls, required)
+
+
+def _wrap_file_serializer_class(cls: serializers.SerializerMetaclass, required: bool):
+    # Implementation notes:
+    # - Do not use ``fsize = serializers.ReadOnlyField(source="fname.size")``
+    #   See bug: https://github.com/tfranzel/drf-spectacular/issues/1303
+    # - Mixin pattern does not work, you get " Field name `fsize` is not valid for model `ChrisFile`."
+    #   Decorator pattern is a workaround.
+    assert type(cls) == serializers.SerializerMetaclass, f'{cls} is not a serializer'
+
+    class _FileSerializer(cls):
+        fname = serializers.FileField(use_url=False, required=required)
+        fsize = serializers.SerializerMethodField()
+        file_resource = ItemLinkField('get_file_link')
+        owner_username = serializers.ReadOnlyField(source='owner.username')
+        parent_folder = serializers.HyperlinkedRelatedField(view_name='chrisfolder-detail', read_only=True)
+        owner = serializers.HyperlinkedRelatedField(view_name='user-detail', read_only=True)
+
+        def get_fsize(self, obj) -> int:
+            """
+            Get the size of the file in bytes.
+            """
+            return obj.fname.size
+
+        @extend_schema_field(OpenApiTypes.URI)
+        def get_file_link(self, obj):
+            """
+            Custom method to get the hyperlink to the actual file resource.
+            """
+            return get_file_resource_link(self, obj)
+
+    _FileSerializer.__name__ = cls.__name__
+    return _FileSerializer

--- a/chris_backend/core/views.py
+++ b/chris_backend/core/views.py
@@ -76,6 +76,8 @@ class FileDownloadTokenList(generics.ListCreateAPIView):
         Overriden to return a custom queryset that is only comprised by the file download
         tokens owned by the currently authenticated user.
         """
+        if getattr(self, "swagger_fake_view", False):
+            return FileDownloadToken.objects.none()
         user = self.request.user
         # if the user is chris then return all the file download tokens in the system
         if user.username == 'chris':
@@ -98,6 +100,8 @@ class FileDownloadTokenListQuerySearch(generics.ListAPIView):
         Overriden to return a custom queryset that is only comprised by the file download
         tokens owned by the currently authenticated user.
         """
+        if getattr(self, "swagger_fake_view", False):
+            return FileDownloadToken.objects.none()
         user = self.request.user
         # if the user is chris then return all the file download tokens in the system
         if user.username == 'chris':

--- a/chris_backend/feeds/serializers.py
+++ b/chris_backend/feeds/serializers.py
@@ -161,7 +161,7 @@ class FeedSerializer(serializers.HyperlinkedModelSerializer):
                      "superuser 'chris'."])
         return public
 
-    def get_created_jobs(self, obj):
+    def get_created_jobs(self, obj) -> int:
         """
         Overriden to get the number of plugin instances in 'created' status.
         """
@@ -169,7 +169,7 @@ class FeedSerializer(serializers.HyperlinkedModelSerializer):
             raise KeyError("Undefined plugin instance execution status: 'created'.")
         return obj.get_plugin_instances_status_count('created')
 
-    def get_waiting_jobs(self, obj):
+    def get_waiting_jobs(self, obj) -> int:
         """
         Overriden to get the number of plugin instances in 'waiting' status.
         """
@@ -178,7 +178,7 @@ class FeedSerializer(serializers.HyperlinkedModelSerializer):
             raise KeyError(msg)
         return obj.get_plugin_instances_status_count('waiting')
 
-    def get_scheduled_jobs(self, obj):
+    def get_scheduled_jobs(self, obj) -> int:
         """
         Overriden to get the number of plugin instances in 'scheduled' status.
         """
@@ -186,7 +186,7 @@ class FeedSerializer(serializers.HyperlinkedModelSerializer):
             raise KeyError("Undefined plugin instance execution status: 'scheduled'.")
         return obj.get_plugin_instances_status_count('scheduled')
 
-    def get_started_jobs(self, obj):
+    def get_started_jobs(self, obj) -> int:
         """
         Overriden to get the number of plugin instances in 'started' status.
         """
@@ -194,7 +194,7 @@ class FeedSerializer(serializers.HyperlinkedModelSerializer):
             raise KeyError("Undefined plugin instance execution status: 'started'.")
         return obj.get_plugin_instances_status_count('started')
 
-    def get_registering_jobs(self, obj):
+    def get_registering_jobs(self, obj) -> int:
         """
         Overriden to get the number of plugin instances in 'registeringFiles' status.
         """
@@ -203,7 +203,7 @@ class FeedSerializer(serializers.HyperlinkedModelSerializer):
             raise KeyError(msg)
         return obj.get_plugin_instances_status_count('registeringFiles')
 
-    def get_finished_jobs(self, obj):
+    def get_finished_jobs(self, obj) -> int:
         """
         Overriden to get the number of plugin instances in 'finishedSuccessfully' status.
         """
@@ -212,7 +212,7 @@ class FeedSerializer(serializers.HyperlinkedModelSerializer):
                            "'finishedSuccessfully'.")
         return obj.get_plugin_instances_status_count('finishedSuccessfully')
 
-    def get_errored_jobs(self, obj):
+    def get_errored_jobs(self, obj) -> int:
         """
         Overriden to get the number of plugin instances in 'finishedWithError' status.
         """
@@ -221,7 +221,7 @@ class FeedSerializer(serializers.HyperlinkedModelSerializer):
                            "'finishedWithError'.")
         return obj.get_plugin_instances_status_count('finishedWithError')
 
-    def get_cancelled_jobs(self, obj):
+    def get_cancelled_jobs(self, obj) -> int:
         """
         Overriden to get the number of plugin instances in 'cancelled' status.
         """

--- a/chris_backend/feeds/views.py
+++ b/chris_backend/feeds/views.py
@@ -3,6 +3,7 @@ from django.db.models import Q
 from django.shortcuts import get_object_or_404
 from rest_framework import generics, permissions
 from rest_framework.reverse import reverse
+from drf_spectacular.utils import extend_schema, extend_schema_view
 
 from collectionjson import services
 from plugininstances.serializers import PluginInstanceSerializer
@@ -39,6 +40,9 @@ class NoteDetail(generics.RetrieveUpdateAPIView):
         return services.append_collection_template(response, template_data)
 
 
+@extend_schema_view(
+    get=extend_schema(operation_id="tags_list")
+)
 class TagList(generics.ListCreateAPIView):
     """
     A view for the collection of tags.
@@ -98,6 +102,9 @@ class TagDetail(generics.RetrieveUpdateDestroyAPIView):
         return services.append_collection_template(response, template_data)
 
 
+@extend_schema_view(
+    get=extend_schema(operation_id="feed_tags_list")
+)
 class FeedTagList(generics.ListAPIView):
     """
     A view for a feed-specific collection of user-specific tags.
@@ -487,6 +494,8 @@ class FeedGroupPermissionListQuerySearch(generics.ListAPIView):
         Overriden to return a custom queryset that is comprised by the feed-specific
         group permissions.
         """
+        if getattr(self, "swagger_fake_view", False):
+            return FeedGroupPermission.objects.none()
         feed = get_object_or_404(Feed, pk=self.kwargs['pk'])
         return FeedGroupPermission.objects.filter(feed=feed)
 
@@ -582,6 +591,8 @@ class FeedUserPermissionListQuerySearch(generics.ListAPIView):
         Overriden to return a custom queryset that is comprised by the feed-specific
         user permissions.
         """
+        if getattr(self, "swagger_fake_view", False):
+            return FeedUserPermission.objects.none()
         feed = get_object_or_404(Feed, pk=self.kwargs['pk'])
         return FeedUserPermission.objects.filter(feed=feed)
 
@@ -678,6 +689,8 @@ class CommentListQuerySearch(generics.ListAPIView):
         Overriden to return a custom queryset that is comprised by the feed-specific
         comments.
         """
+        if getattr(self, 'swagger_fake_view', False):
+            return Feed.comments.field.model.objects.none()
         feed = get_object_or_404(Feed, pk=self.kwargs['pk'])
         return feed.comments.all()
 
@@ -702,6 +715,9 @@ class CommentDetail(generics.RetrieveUpdateDestroyAPIView):
         return services.append_collection_template(response, template_data)
 
 
+# @extend_schema_view(
+#     get=extend_schema(operation_id='feed_plugins_instances_list')
+# )
 class FeedPluginInstanceList(generics.ListAPIView):
     """
     A view for the collection of feed-specific plugin instances.

--- a/chris_backend/filebrowser/views.py
+++ b/chris_backend/filebrowser/views.py
@@ -6,6 +6,7 @@ from django.shortcuts import get_object_or_404
 from rest_framework import generics, permissions, serializers
 from rest_framework.reverse import reverse
 from rest_framework.authentication import BasicAuthentication, SessionAuthentication
+from drf_spectacular.utils import extend_schema, OpenApiResponse, OpenApiTypes
 
 from core.models import (ChrisFolder, FolderGroupPermission,
                          FolderGroupPermissionFilter, FolderUserPermission,
@@ -76,6 +77,8 @@ class FileBrowserFolderList(generics.ListCreateAPIView):
         Overriden to return a custom queryset that is only comprised by the root
         folder (empty path).
         """
+        if getattr(self, "swagger_fake_view", False):
+            return ChrisFolder.objects.none()
         user = self.request.user
         pk_dict = {'path': ''}
 
@@ -101,6 +104,9 @@ class FileBrowserFolderListQuerySearch(generics.ListAPIView):
         """
         Overriden to return a custom queryset of at most one element.
         """
+        if getattr(self, "swagger_fake_view", False):
+            return ChrisFolder.objects.none()
+
         user = self.request.user
         id = self.request.GET.get('id')
         pk_dict = {'id': id}
@@ -244,6 +250,8 @@ class FileBrowserFolderGroupPermissionListQuerySearch(generics.ListAPIView):
         Overriden to return a custom queryset that is comprised by the folder-specific
         group permissions.
         """
+        if getattr(self, "swagger_fake_view", False):
+            return FolderGroupPermission.objects.none()
         folder = get_object_or_404(ChrisFolder, pk=self.kwargs['pk'])
         return FolderGroupPermission.objects.filter(folder=folder)
 
@@ -357,6 +365,8 @@ class FileBrowserFolderUserPermissionListQuerySearch(generics.ListAPIView):
         Overriden to return a custom queryset that is comprised by the folder-specific
         user permissions.
         """
+        if getattr(self, "swagger_fake_view", False):
+            return FolderUserPermission.objects.none()
         folder = get_object_or_404(ChrisFolder, pk=self.kwargs['pk'])
         return FolderUserPermission.objects.filter(folder=folder)
 
@@ -476,6 +486,7 @@ class FileBrowserFileResource(generics.GenericAPIView):
     authentication_classes = (TokenAuthSupportQueryString, BasicAuthentication,
                               SessionAuthentication)
 
+    @extend_schema(responses=OpenApiResponse(OpenApiTypes.BINARY))
     def get(self, request, *args, **kwargs):
         """
         Overriden to be able to make a GET request to an actual file resource.
@@ -547,6 +558,8 @@ class FileBrowserFileGroupPermissionListQuerySearch(generics.ListAPIView):
         Overriden to return a custom queryset that is comprised by the file-specific
         group permissions.
         """
+        if getattr(self, "swagger_fake_view", False):
+            return FileGroupPermission.objects.none()
         f = get_object_or_404(ChrisFile, pk=self.kwargs['pk'])
         return FileGroupPermission.objects.filter(file=f)
 
@@ -660,6 +673,8 @@ class FileBrowserFileUserPermissionListQuerySearch(generics.ListAPIView):
         Overriden to return a custom queryset that is comprised by the file-specific
         user permissions.
         """
+        if getattr(self, "swagger_fake_view", False):
+            return FileUserPermission.objects.none()
         f = get_object_or_404(ChrisFile, pk=self.kwargs['pk'])
         return FileUserPermission.objects.filter(file=f)
 
@@ -799,6 +814,7 @@ class FileBrowserLinkFileResource(generics.GenericAPIView):
     authentication_classes = (TokenAuthSupportQueryString, BasicAuthentication,
                               SessionAuthentication)
 
+    @extend_schema(responses=OpenApiResponse(OpenApiTypes.BINARY))
     def get(self, request, *args, **kwargs):
         """
         Overriden to be able to make a GET request to an actual file resource.
@@ -870,6 +886,8 @@ class FileBrowserLinkFileGroupPermissionListQuerySearch(generics.ListAPIView):
         Overriden to return a custom queryset that is comprised by the link file-specific
         group permissions.
         """
+        if getattr(self, "swagger_fake_view", False):
+            return LinkFileGroupPermission.objects.none()
         lf = get_object_or_404(ChrisLinkFile, pk=self.kwargs['pk'])
         return LinkFileGroupPermission.objects.filter(link_file=lf)
 
@@ -983,6 +1001,8 @@ class FileBrowserLinkFileUserPermissionListQuerySearch(generics.ListAPIView):
         Overriden to return a custom queryset that is comprised by the link file-specific
         user permissions.
         """
+        if getattr(self, "swagger_fake_view", False):
+            return LinkFileUserPermission.objects.none()
         lf = get_object_or_404(ChrisLinkFile, pk=self.kwargs['pk'])
         return LinkFileUserPermission.objects.filter(link_file=lf)
 

--- a/chris_backend/pacsfiles/serializers.py
+++ b/chris_backend/pacsfiles/serializers.py
@@ -7,10 +7,9 @@ from django.contrib.auth.models import Group
 from django.conf import settings
 from rest_framework import serializers
 
-from collectionjson.fields import ItemLinkField
 from core.models import ChrisFolder
-from core.utils import get_file_resource_link
 from core.storage import connect_storage
+from core.serializers import file_serializer
 
 from .models import PACS, PACSSeries, PACSFile
 
@@ -168,22 +167,10 @@ class PACSSeriesSerializer(serializers.HyperlinkedModelSerializer):
         return data
 
 
+@file_serializer(required=True)
 class PACSFileSerializer(serializers.HyperlinkedModelSerializer):
-    fname = serializers.FileField(use_url=False)
-    fsize = serializers.ReadOnlyField(source='fname.size')
-    owner_username = serializers.ReadOnlyField(source='owner.username')
-    file_resource = ItemLinkField('get_file_link')
-    parent_folder = serializers.HyperlinkedRelatedField(view_name='chrisfolder-detail',
-                                                        read_only=True)
-    owner = serializers.HyperlinkedRelatedField(view_name='user-detail', read_only=True)
 
     class Meta:
         model = PACSFile
         fields = ('url', 'id', 'creation_date', 'fname', 'fsize', 'public',
                   'owner_username', 'file_resource', 'parent_folder', 'owner')
-
-    def get_file_link(self, obj):
-        """
-        Custom method to get the hyperlink to the actual file resource.
-        """
-        return get_file_resource_link(self, obj)

--- a/chris_backend/pacsfiles/views.py
+++ b/chris_backend/pacsfiles/views.py
@@ -3,6 +3,7 @@ from django.http import FileResponse
 from rest_framework import generics, permissions
 from rest_framework.reverse import reverse
 from rest_framework.authentication import BasicAuthentication, SessionAuthentication
+from drf_spectacular.utils import extend_schema, OpenApiResponse, OpenApiTypes
 
 from collectionjson import services
 from core.renderers import BinaryFileRenderer
@@ -119,6 +120,7 @@ class PACSFileResource(generics.GenericAPIView):
     authentication_classes = (TokenAuthSupportQueryString, BasicAuthentication,
                               SessionAuthentication)
 
+    @extend_schema(responses=OpenApiResponse(OpenApiTypes.BINARY))
     def get(self, request, *args, **kwargs):
         """
         Overriden to be able to make a GET request to an actual file resource.

--- a/chris_backend/pipelines/views.py
+++ b/chris_backend/pipelines/views.py
@@ -6,6 +6,7 @@ from django.contrib.auth.models import User
 
 from rest_framework import generics, permissions
 from rest_framework.reverse import reverse
+from drf_spectacular.utils import extend_schema, OpenApiResponse, OpenApiTypes
 
 from core.renderers import BinaryFileRenderer
 from collectionjson import services
@@ -195,6 +196,7 @@ class PipelineSourceFileResource(generics.GenericAPIView):
     queryset = PipelineSourceFile.get_base_queryset()
     renderer_classes = (BinaryFileRenderer,)
 
+    @extend_schema(responses=OpenApiResponse(OpenApiTypes.BINARY))
     def get(self, request, *args, **kwargs):
         """
         Overriden to be able to make a GET request to an actual file resource.

--- a/chris_backend/plugininstances/spectacular_hooks.py
+++ b/chris_backend/plugininstances/spectacular_hooks.py
@@ -7,6 +7,8 @@ def additionalproperties_for_plugins_instances_create(result, **_kwargs):
 
     :param result: an OpenAPI specification
     """
+    if 'PluginInstanceRequest' not in result['components']['schemas']:
+        return result
     plugin_instance_request = result['components']['schemas']['PluginInstanceRequest']
     assert plugin_instance_request['type'] == 'object'
     plugin_instance_request['additionalProperties'] = {}
@@ -17,4 +19,3 @@ def additionalproperties_for_plugins_instances_create(result, **_kwargs):
         'nullable': True
     }
     return result
-

--- a/chris_backend/plugininstances/views.py
+++ b/chris_backend/plugininstances/views.py
@@ -3,6 +3,7 @@ from rest_framework import generics
 from rest_framework import permissions
 from rest_framework.reverse import reverse
 from rest_framework.serializers import ValidationError
+from drf_spectacular.utils import extend_schema_view, extend_schema
 
 from collectionjson import services
 from plugins.models import Plugin
@@ -20,6 +21,9 @@ from .tasks import run_plugin_instance, cancel_plugin_instance
 from .utils import run_if_ready
 
 
+@extend_schema_view(
+    get=extend_schema(operation_id='plugins_instances_list')
+)
 class PluginInstanceList(generics.ListCreateAPIView):
     """
     A view for the collection of plugin instances.
@@ -118,6 +122,9 @@ class PluginInstanceList(generics.ListCreateAPIView):
         return self.filter_queryset(plugin.instances.all())
 
 
+@extend_schema_view(
+    get=extend_schema(operation_id='all_plugins_instances_list')
+)
 class AllPluginInstanceList(generics.ListAPIView):
     """
     A view for the collection of all plugin instances.

--- a/chris_backend/plugins/admin.py
+++ b/chris_backend/plugins/admin.py
@@ -15,7 +15,8 @@ from rest_framework.reverse import reverse
 
 from collectionjson import services
 
-from .models import PluginMeta, Plugin, ComputeResource, TYPES
+from .enums import TYPES
+from .models import PluginMeta, Plugin, ComputeResource
 from .fields import CPUInt, MemoryInt
 from .serializers import (ComputeResourceSerializer, PluginMetaSerializer,
                           PluginSerializer, PluginParameterSerializer,

--- a/chris_backend/plugins/enums.py
+++ b/chris_backend/plugins/enums.py
@@ -1,0 +1,12 @@
+
+# front-end API types
+TYPE_CHOICES = [("string", "String values"), ("float", "Float values"),
+                ("boolean", "Boolean values"), ("integer", "Integer values"),
+                ("path", "Path values"), ("unextpath", "Unextracted path values")]
+
+# table of equivalence between front-end API types and back-end types
+TYPES = {'string': 'str', 'integer': 'int', 'float': 'float', 'boolean': 'bool',
+         'path': 'path', 'unextpath': 'unextpath'}
+
+PLUGIN_TYPE_CHOICES = [("ds", "Data synthesis"), ("fs", "Feed synthesis"),
+                       ("ts", "Topology synthesis")]

--- a/chris_backend/plugins/models.py
+++ b/chris_backend/plugins/models.py
@@ -6,19 +6,7 @@ from django_filters.rest_framework import FilterSet
 from django.core.exceptions import ValidationError
 
 from .fields import CPUField, MemoryField
-
-
-# front-end API types
-TYPE_CHOICES = [("string", "String values"), ("float", "Float values"),
-                ("boolean", "Boolean values"), ("integer", "Integer values"),
-                ("path", "Path values"), ("unextpath", "Unextracted path values")]
-
-# table of equivalence between front-end API types and back-end types
-TYPES = {'string': 'str', 'integer': 'int', 'float': 'float', 'boolean': 'bool',
-         'path': 'path', 'unextpath': 'unextpath'}
-
-PLUGIN_TYPE_CHOICES = [("ds", "Data synthesis"), ("fs", "Feed synthesis"),
-                       ("ts", "Topology synthesis")]
+from .enums import TYPE_CHOICES, PLUGIN_TYPE_CHOICES
 
 
 class ComputeResource(models.Model):

--- a/chris_backend/plugins/serializers.py
+++ b/chris_backend/plugins/serializers.py
@@ -221,7 +221,7 @@ class PluginParameterSerializer(serializers.HyperlinkedModelSerializer):
             raise serializers.ValidationError({'non_field_errors': [error_msg]})
         return data
 
-    def get_default(self, obj):
+    def get_default(self, obj) -> str | int | float | bool | None:
         """
         Overriden to get the default parameter value regardless of type.
         """

--- a/chris_backend/userfiles/serializers.py
+++ b/chris_backend/userfiles/serializers.py
@@ -4,27 +4,20 @@ import os
 from django.conf import settings
 from rest_framework import serializers
 
-from collectionjson.fields import ItemLinkField
-from core.utils import get_file_resource_link
 from core.models import ChrisFolder
 from core.storage import connect_storage
+from core.serializers import file_serializer
 
 from .models import UserFile
 
 
+@file_serializer(required=False)
 class UserFileSerializer(serializers.HyperlinkedModelSerializer):
-    fname = serializers.FileField(use_url=False, required=False)
-    fsize = serializers.ReadOnlyField(source='fname.size')
     upload_path = serializers.CharField(max_length=1024, write_only=True, required=False)
-    owner_username = serializers.ReadOnlyField(source='owner.username')
-    file_resource = ItemLinkField('get_file_link')
-    parent_folder = serializers.HyperlinkedRelatedField(view_name='chrisfolder-detail',
-                                                        read_only=True)
     group_permissions = serializers.HyperlinkedIdentityField(
         view_name='filegrouppermission-list')
     user_permissions = serializers.HyperlinkedIdentityField(
         view_name='fileuserpermission-list')
-    owner = serializers.HyperlinkedRelatedField(view_name='user-detail', read_only=True)
 
     class Meta:
         model = UserFile
@@ -88,12 +81,6 @@ class UserFileSerializer(serializers.HyperlinkedModelSerializer):
 
         instance.save()
         return instance
-
-    def get_file_link(self, obj):
-        """
-        Custom method to get the hyperlink to the actual file resource.
-        """
-        return get_file_resource_link(self, obj)
 
     def validate_upload_path(self, upload_path):
         """

--- a/chris_backend/userfiles/views.py
+++ b/chris_backend/userfiles/views.py
@@ -4,6 +4,7 @@ from django.http import FileResponse
 from rest_framework import generics, permissions
 from rest_framework.reverse import reverse
 from rest_framework.authentication import BasicAuthentication, SessionAuthentication
+from drf_spectacular.utils import extend_schema, OpenApiResponse, OpenApiTypes
 
 from collectionjson import services
 from core.renderers import BinaryFileRenderer
@@ -26,6 +27,9 @@ class UserFileList(generics.ListCreateAPIView):
         Overriden to return a custom queryset that is only comprised by the files
         owned by the currently authenticated user.
         """
+        if getattr(self, "swagger_fake_view", False):
+            return UserFile.objects.none()
+
         user = self.request.user
 
         # if the user is chris then return all the files in the user space
@@ -69,6 +73,8 @@ class UserFileListQuerySearch(generics.ListAPIView):
         Overriden to return a custom queryset that is only comprised by the files
         owned by the currently authenticated user.
         """
+        if getattr(self, "swagger_fake_view", False):
+            return UserFile.objects.none()
         user = self.request.user
 
         # if the user is chris then return all the files in the user space
@@ -115,6 +121,7 @@ class UserFileResource(generics.GenericAPIView):
     authentication_classes = (TokenAuthSupportQueryString, BasicAuthentication,
                               SessionAuthentication)
 
+    @extend_schema(responses=OpenApiResponse(OpenApiTypes.BINARY))
     def get(self, request, *args, **kwargs):
         """
         Overriden to be able to make a GET request to an actual file resource.

--- a/chris_backend/users/views.py
+++ b/chris_backend/users/views.py
@@ -201,6 +201,8 @@ class GroupUserListQuerySearch(generics.ListAPIView):
         Overriden to return a custom queryset that is comprised by the group-specific
         group users.
         """
+        if getattr(self, "swagger_fake_view", False):
+            return User.groups.through.objects.none()
         group = get_object_or_404(Group, pk=self.kwargs['pk'])
         return User.groups.through.objects.filter(group=group)
 

--- a/chris_backend/workflows/serializers.py
+++ b/chris_backend/workflows/serializers.py
@@ -205,7 +205,7 @@ class WorkflowSerializer(serializers.HyperlinkedModelSerializer):
                     {'previous_plugin_inst_id': ["This field is required."]})
         return data
 
-    def get_created_jobs(self, obj):
+    def get_created_jobs(self, obj) -> int:
         """
         Overriden to get the number of plugin instances in 'created' status.
         """
@@ -213,7 +213,7 @@ class WorkflowSerializer(serializers.HyperlinkedModelSerializer):
             raise KeyError("Undefined plugin instance execution status: 'created'.")
         return obj.get_plugin_instances_status_count('created')
 
-    def get_waiting_jobs(self, obj):
+    def get_waiting_jobs(self, obj) -> int:
         """
         Overriden to get the number of plugin instances in 'waiting' status.
         """
@@ -222,7 +222,7 @@ class WorkflowSerializer(serializers.HyperlinkedModelSerializer):
             raise KeyError(msg)
         return obj.get_plugin_instances_status_count('waiting')
 
-    def get_scheduled_jobs(self, obj):
+    def get_scheduled_jobs(self, obj) -> int:
         """
         Overriden to get the number of plugin instances in 'scheduled' status.
         """
@@ -230,7 +230,7 @@ class WorkflowSerializer(serializers.HyperlinkedModelSerializer):
             raise KeyError("Undefined plugin instance execution status: 'scheduled'.")
         return obj.get_plugin_instances_status_count('scheduled')
 
-    def get_started_jobs(self, obj):
+    def get_started_jobs(self, obj) -> int:
         """
         Overriden to get the number of plugin instances in 'started' status.
         """
@@ -238,7 +238,7 @@ class WorkflowSerializer(serializers.HyperlinkedModelSerializer):
             raise KeyError("Undefined plugin instance execution status: 'started'.")
         return obj.get_plugin_instances_status_count('started')
 
-    def get_registering_jobs(self, obj):
+    def get_registering_jobs(self, obj) -> int:
         """
         Overriden to get the number of plugin instances in 'registeringFiles' status.
         """
@@ -247,7 +247,7 @@ class WorkflowSerializer(serializers.HyperlinkedModelSerializer):
             raise KeyError(msg)
         return obj.get_plugin_instances_status_count('registeringFiles')
 
-    def get_finished_jobs(self, obj):
+    def get_finished_jobs(self, obj) -> int:
         """
         Overriden to get the number of plugin instances in 'finishedSuccessfully' status.
         """
@@ -256,7 +256,7 @@ class WorkflowSerializer(serializers.HyperlinkedModelSerializer):
                            "'finishedSuccessfully'.")
         return obj.get_plugin_instances_status_count('finishedSuccessfully')
 
-    def get_errored_jobs(self, obj):
+    def get_errored_jobs(self, obj) -> int:
         """
         Overriden to get the number of plugin instances in 'finishedWithError' status.
         """
@@ -265,7 +265,7 @@ class WorkflowSerializer(serializers.HyperlinkedModelSerializer):
                            "'finishedWithError'.")
         return obj.get_plugin_instances_status_count('finishedWithError')
 
-    def get_cancelled_jobs(self, obj):
+    def get_cancelled_jobs(self, obj) -> int:
         """
         Overriden to get the number of plugin instances in 'cancelled' status.
         """

--- a/chris_backend/workflows/views.py
+++ b/chris_backend/workflows/views.py
@@ -4,6 +4,7 @@ from collections import deque
 
 from rest_framework import generics, permissions
 from rest_framework.reverse import reverse
+from drf_spectacular.utils import extend_schema, extend_schema_view
 
 from collectionjson import services
 from pipelines.models import Pipeline
@@ -17,7 +18,9 @@ from .models import Workflow, WorkflowFilter
 from .permissions import IsOwnerOrChrisOrReadOnly
 from .serializers import WorkflowSerializer
 
-
+@extend_schema_view(
+    get=extend_schema(operation_id="workflows_list")
+)
 class WorkflowList(generics.ListCreateAPIView):
     """
     A view for the collection of pipeline-specific workflows.
@@ -134,6 +137,9 @@ class WorkflowList(generics.ListCreateAPIView):
         return plg_inst
 
 
+@extend_schema_view(
+    get=extend_schema(operation_id="all_workflows_list")
+)
 class AllWorkflowList(generics.ListAPIView):
     """
     A view for the collection of all workflows.

--- a/docker-compose_just.yml
+++ b/docker-compose_just.yml
@@ -31,7 +31,7 @@ services:
     environment: &CHRIS_ENV
       DJANGO_SETTINGS_MODULE: "config.settings.local"
       STORAGE_ENV: "fslink"
-      SPECTACULAR_SPLIT_REQUEST: "true"
+      SPECTACULAR_SPLIT_REQUEST: "${SPECTACULAR_SPLIT_REQUEST-false}"
     user: ${UID:?Please run me using just.}:${GID:?Please run me using just.}
     profiles:
       - cube

--- a/justfile
+++ b/justfile
@@ -153,8 +153,14 @@ prefer docker_or_podman:
 unset-preference:
     rm -f .preference
 
-[group('(6) OpenAPI generator')]
-openapi-generate output +options:
-    mkdir -vp {{output}}
-    @env OPENAPI_GENERATOR_OUTPUT="$(realpath {{output}})" just docker-compose run --rm openapi-generator \
-        generate {{ options }} -i http://chris:8000/schema/ -o /out
+# Print the OpenAPI schema via drf-spectacular.
+[group('(3) development')]
+openapi:
+    @just run python manage.py spectacular --color
+
+# Print the OpenAPI schema using drf-spectacular, using workarounds for more
+# reliable client generation.
+[group('(3) development')]
+openapi-split:
+    env SPECTACULAR_SPLIT_REQUEST=true just openapi
+


### PR DESCRIPTION
- Most `get_queryset` overrides need to have an extra two lines of code `if getattr(self, "swagger_fake_view", False): return TheModel.objects.none()`
- Added a class decorator `@core.serializers.file_serializer` which unifies the duplicated code between file serializers which provide the fields `fname`, `fsize`, `file_resource`, `owner_username`, `parent_folder`, and `owner`
