### PR TITLE
Replace daphne with granian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,4 @@ COPY chris_backend/ ./
 RUN if [ "$ENVIRONMENT" = "production" ]; then \
     env DJANGO_SETTINGS_MODULE=config.settings.common ./manage.py collectstatic; fi
 
-CMD ["daphne", "-b", "0.0.0.0", "-p", "8000", "config.asgi:application"]
+CMD ["granian", "--host", "0.0.0.0", "--interface", "asginl", "config.asgi:application"]

--- a/chris_backend/config/settings/common.py
+++ b/chris_backend/config/settings/common.py
@@ -28,7 +28,6 @@ BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 # Application definition
 INSTALLED_APPS = [
-    'daphne',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',

--- a/docker-compose_just.yml
+++ b/docker-compose_just.yml
@@ -22,7 +22,6 @@ services:
       context: .
       args:
         ENVIRONMENT: local
-    command: bash -c 'python manage.py runserver 0.0.0.0:8000 2> >(grep -vF "HTTP GET /api/v1/users/ 200" 1>&2)'
     ports:
       - "8000:8000"
     volumes: &CHRIS_VOLUMES
@@ -32,6 +31,7 @@ services:
       DJANGO_SETTINGS_MODULE: "config.settings.local"
       STORAGE_ENV: "fslink"
       SPECTACULAR_SPLIT_REQUEST: "${SPECTACULAR_SPLIT_REQUEST-false}"
+      GRANIAN_RELOAD: "true"
     user: ${UID:?Please run me using just.}:${GID:?Please run me using just.}
     profiles:
       - cube

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,6 +14,7 @@ django-auth-ldap==4.5.0
 PyYAML==6.0.1
 whitenoise[brotli]==6.5.0
 PyJWT===2.8.0
-channels[daphne]==4.1.0
+channels==4.1.0
 nats-py==2.9.0
+granian==1.6.1
 git+https://github.com/tfranzel/drf-spectacular.git@refs/pull/1307/head

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -8,4 +8,6 @@ pylint==2.17.5
 flake8==6.1.0
 isort==5.12.0
 pudb==2022.1.3
+daphne==4.1.2  # required by (django) channels.testing
+granian[reload]
 https://github.com/msbrogli/rpudb/archive/master.zip

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,3 +1,2 @@
 -r base.txt # includes the base.txt requirements
 
-gunicorn==21.2.0


### PR DESCRIPTION
granian is an ASGI server written in Rust. In addition to adding rusty performance and goodness, this also solves a problem with large file uploads that happens with daphne (see https://stackoverflow.com/questions/46986220/daphne-django-file-upload-size-limitations).

I tried uploading an 8GB file and it worked no problem.