### PR TITLE
Add more optional environment variables for LDAP

### DIFF
--- a/chris_backend/config/settings/production.py
+++ b/chris_backend/config/settings/production.py
@@ -171,20 +171,28 @@ if AUTH_LDAP:
     AUTH_LDAP_GROUP_SEARCH_ROOT = get_secret('AUTH_LDAP_GROUP_SEARCH_ROOT')
     AUTH_LDAP_CHRIS_ADMIN_GROUP = get_secret('AUTH_LDAP_CHRIS_ADMIN_GROUP')
 
+    _user_search = env.str('AUTH_LDAP_USER_SEARCH_FILTER', default='(uid=%(user)s)')
     AUTH_LDAP_USER_SEARCH = LDAPSearch(AUTH_LDAP_USER_SEARCH_ROOT, ldap.SCOPE_SUBTREE,
-                                       '(uid=%(user)s)')
-    AUTH_LDAP_USER_ATTR_MAP = {
-        'first_name': 'givenName',
-        'last_name': 'sn',
-        'email': 'mail'
-    }
+                                       _user_search)
+    AUTH_LDAP_USER_ATTR_MAP = env.dict(
+        'AUTH_LDAP_USER_ATTR_MAP',
+        default={
+            'first_name': 'givenName',
+            'last_name': 'sn',
+            'email': 'mail'
+        }
+    )
+    _group_search = env.str('AUTH_LDAP_GROUP_SEARCH_FILTER', default='(objectClass=groupOfNames)')
     AUTH_LDAP_GROUP_SEARCH = LDAPSearch(AUTH_LDAP_GROUP_SEARCH_ROOT, ldap.SCOPE_SUBTREE,
-                                        '(objectClass=groupOfNames)')
+                                        _group_search)
     AUTH_LDAP_GROUP_TYPE = GroupOfNamesType()
-    AUTH_LDAP_USER_FLAGS_BY_GROUP = {
-        'is_staff': f'cn={AUTH_LDAP_CHRIS_ADMIN_GROUP},{AUTH_LDAP_GROUP_SEARCH_ROOT}'
-    }
-    AUTH_LDAP_MIRROR_GROUPS_EXCEPT = ['all_users']
+    AUTH_LDAP_USER_FLAGS_BY_GROUP = env.dict(
+        'AUTH_LDAP_USER_FLAGS_BY_GROUP',
+        default={
+            'is_staff': f'cn={AUTH_LDAP_CHRIS_ADMIN_GROUP},{AUTH_LDAP_GROUP_SEARCH_ROOT}'
+        }
+    )
+    AUTH_LDAP_MIRROR_GROUPS_EXCEPT = env.list('AUTH_LDAP_MIRROR_GROUPS_EXCEPT', default=['all_users'])
 
     AUTHENTICATION_BACKENDS = (
         'users.models.CustomLDAPBackend',


### PR DESCRIPTION
Adds the optional environment variables `AUTH_LDAP_USER_SEARCH_FILTER`, `AUTH_LDAP_USER_ATTR_MAP`, `AUTH_LDAP_GROUP_SEARCH_FILTER`, `AUTH_LDAP_USER_FLAGS_BY_GROUP`, and `AUTH_LDAP_MIRROR_GROUPS_EXCEPT`, making LDAP integration much more customizable. In particular, this enables the configuration of workarounds for problems with Authentik's LDAP outpost --> https://github.com/goauthentik/authentik/issues/7522#issuecomment-2525303023