### PR TITLE
Filter out healthcheck endpoint from logs

### DIFF
--- a/justfile
+++ b/justfile
@@ -23,7 +23,7 @@ up: (docker-compose '--profile=cube up -d')
 
 # Attach to the chris container.
 [group('(3) development')]
-attach: (docker-compose '--profile=cube attach chris')
+attach: (docker-compose '--profile=cube attach chris | grep -Fv "\"GET /api/v1/users/ HTTP/1.1\" 200"')
 
 # Open a Python shell.
 [group('(3) development')]


### PR DESCRIPTION
Prevents the output of `just dev` from being so noisy...