### PR TITLE
Make delete requests to pfcon more robust and add periodic task to retry failed requests

### DIFF
--- a/chris_backend/core/celery.py
+++ b/chris_backend/core/celery.py
@@ -27,11 +27,14 @@ task_routes = {
     'plugininstances.tasks.run_plugin_instance': {'queue': 'main1'},
     'plugininstances.tasks.check_plugin_instance_exec_status': {'queue': 'main2'},
     'plugininstances.tasks.cancel_plugin_instance': {'queue': 'main2'},
+    'plugininstances.tasks.delete_plugin_instance_job_from_remote': {'queue': 'main2'},
     'plugininstances.tasks.schedule_waiting_plugin_instances':
         {'queue': 'periodic'},
     'plugininstances.tasks.check_started_plugin_instances_exec_status':
         {'queue': 'periodic'},
     'plugininstances.tasks.cancel_waiting_plugin_instances':
+        {'queue': 'periodic'},
+    'plugininstances.tasks.delete_plugin_instances_jobs_from_remote':
         {'queue': 'periodic'},
     'pacsfiles.tasks.send_pacs_query': {'queue': 'main2'},
     'pacsfiles.tasks.register_pacs_series': {'queue': 'main2'}
@@ -58,6 +61,10 @@ app.conf.beat_schedule = {
     'cancel-waiting-plugin-instances-every-30-seconds': {
         'task': 'plugininstances.tasks.cancel_waiting_plugin_instances',
         'schedule': POLL_INTERVAL,
+    },
+    'delete-plugin-instances-jobs-from-remote-every-7200-seconds': {
+        'task': 'plugininstances.tasks.delete_plugin_instances_jobs_from_remote',
+        'schedule': 7200.0,
     },
 }
 

--- a/chris_backend/feeds/tests/test_models.py
+++ b/chris_backend/feeds/tests/test_models.py
@@ -1,21 +1,25 @@
 
 import logging
+import io
 
 from django.test import TestCase
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User, Group
 from django.conf import settings
 
+from core.models import (ChrisFolder, ChrisLinkFile)
+from core.storage import connect_storage
 from plugins.models import PluginMeta, Plugin, PluginParameter, ComputeResource
 from plugininstances.models import PluginInstance
-from feeds.models import Note, Feed
+from userfiles.models import UserFile
+from feeds.models import Note, Feed, FeedGroupPermission, FeedUserPermission
 
 
 COMPUTE_RESOURCE_URL = settings.COMPUTE_RESOURCE_URL
 CHRIS_SUPERUSER_PASSWORD = settings.CHRIS_SUPERUSER_PASSWORD
 
 
-class FeedModelTests(TestCase):
-    
+class ModelTests(TestCase):
+
     def setUp(self):
         # avoid cluttered console output (for instance logging all the http requests)
         logging.disable(logging.WARNING)
@@ -31,6 +35,8 @@ class FeedModelTests(TestCase):
                                   'img_type': {'type': 'string', 'optional': True}}
         self.username = 'foo'
         self.password = 'bar'
+        self.other_username = 'boo'
+        self.other_password = 'far'
 
         (self.compute_resource, tf) = ComputeResource.objects.get_or_create(
             name="host", compute_url=COMPUTE_RESOURCE_URL)
@@ -49,9 +55,17 @@ class FeedModelTests(TestCase):
             type=self.plugin_parameters['mrn']['type'],
             optional=self.plugin_parameters['mrn']['optional'])
 
-        # create user
+        # create users
+        other_user = User.objects.create_user(username=self.other_username,
+                                              password=self.other_password)
         user = User.objects.create_user(username=self.username,
                                         password=self.password)
+
+        # assign predefined group
+        all_grp = Group.objects.get(name='all_users')
+
+        other_user.groups.set([all_grp])
+        user.groups.set([all_grp])
 
         # create a plugin instance that in turn creates a new feed
         (plg_inst, tf) = PluginInstance.objects.get_or_create(
@@ -62,6 +76,9 @@ class FeedModelTests(TestCase):
     def tearDown(self):
         # re-enable logging
         logging.disable(logging.NOTSET)
+
+
+class FeedModelTests(ModelTests):
 
     def test_save_creates_new_note_just_after_feed_is_created(self):
         """
@@ -115,3 +132,231 @@ class FeedModelTests(TestCase):
         self.assertEqual(count, 0)
         count = feed.get_jobs_status_count()['cancelled_jobs']
         self.assertEqual(count, 0)
+
+
+class FeedGroupPermissionTests(ModelTests):
+
+    def test_save(self):
+        """
+        Test whether overriden save method grants the group write permission to all the
+        folders, files and link files within the feed's folder. In addition, tests
+        whether the same permission is applied to all objects pointed by the linked
+        files under the feed's folder if they are owned by the feed's owner.
+        """
+        user = User.objects.get(username=self.username)
+        grp = Group.objects.get(name='all_users')
+        feed = Feed.objects.get(name=self.feed_name)
+        folder = feed.folder.children.first()
+
+        # create a file within the folder
+        storage_manager = connect_storage(settings)
+        file_path = f'{folder.path}/file.txt'
+        with io.StringIO("test file") as fi:
+            storage_manager.upload_obj(file_path, fi.read(),
+                                       content_type='text/plain')
+        f = UserFile(owner=user, parent_folder=folder)
+        f.fname.name = file_path
+        f.save()
+
+        # create a link file within the folder
+        lf = ChrisLinkFile(path=f'home/{self.username}/uploads', owner=user,
+                           parent_folder=folder)
+        lf.save(name=f'home_{self.username}_uploads')
+
+        # create a file within the pointed folder
+        pointed_folder, tf = ChrisFolder.objects.get_or_create(
+            path=f'home/{self.username}/uploads', owner=user)
+        file_path = f'{pointed_folder.path}/file1.txt'
+        with io.StringIO("test file") as fi:
+            storage_manager.upload_obj(file_path, fi.read(),
+                                       content_type='text/plain')
+        pf = UserFile(owner=user, parent_folder=pointed_folder)
+        pf.fname.name = file_path
+        pf.save()
+
+        perm = FeedGroupPermission(feed=feed, group=grp)
+        perm.save()
+
+        grps = folder.shared_groups.values_list('name', flat=True)
+        self.assertIn('all_users', grps)
+
+        grps = f.shared_groups.values_list('name', flat=True)
+        self.assertIn('all_users', grps)
+
+        grps = lf.shared_groups.values_list('name', flat=True)
+        self.assertIn('all_users', grps)
+
+        grps = pf.shared_groups.values_list('name', flat=True)
+        self.assertIn('all_users', grps)
+
+        ChrisFolder.objects.get(path=f'home/{self.username}').delete()
+
+    def test_delete(self):
+        """
+        Test whether overriden delete method removes the group's write permission from all
+        the folders, files and link files within the feed's folder. In addition, tests
+        whether the same permission is removed from all objects pointed by the linked
+        files under the feed's folder if they are owned by the feed's owner.
+        """
+        user = User.objects.get(username=self.username)
+        grp = Group.objects.get(name='all_users')
+        feed = Feed.objects.get(name=self.feed_name)
+        folder = feed.folder.children.first()
+
+        # create a file within the folder
+        storage_manager = connect_storage(settings)
+        file_path = f'{folder.path}/file.txt'
+        with io.StringIO("test file") as fi:
+            storage_manager.upload_obj(file_path, fi.read(),
+                                       content_type='text/plain')
+        f = UserFile(owner=user, parent_folder=folder)
+        f.fname.name = file_path
+        f.save()
+
+        # create a link file within the folder
+        lf = ChrisLinkFile(path=f'home/{self.username}/uploads', owner=user,
+                           parent_folder=folder)
+        lf.save(name=f'home_{self.username}_uploads')
+
+        # create a file within the pointed folder
+        pointed_folder, tf = ChrisFolder.objects.get_or_create(
+            path=f'home/{self.username}/uploads', owner=user)
+        file_path = f'{pointed_folder.path}/file1.txt'
+        with io.StringIO("test file") as fi:
+            storage_manager.upload_obj(file_path, fi.read(),
+                                       content_type='text/plain')
+        pf = UserFile(owner=user, parent_folder=pointed_folder)
+        pf.fname.name = file_path
+        pf.save()
+
+        perm = FeedGroupPermission(feed=feed, group=grp)
+        perm.save()
+        perm.delete()
+
+        grps = folder.shared_groups.values_list('name', flat=True)
+        self.assertNotIn('all_users', grps)
+
+        grps = f.shared_groups.values_list('name', flat=True)
+        self.assertNotIn('all_users', grps)
+
+        grps = lf.shared_groups.values_list('name', flat=True)
+        self.assertNotIn('all_users', grps)
+
+        grps = pf.shared_groups.values_list('name', flat=True)
+        self.assertNotIn('all_users', grps)
+
+        ChrisFolder.objects.get(path=f'home/{self.username}').delete()
+
+
+class FeedUserPermissionTests(ModelTests):
+
+    def test_save(self):
+        """
+        Test whether overriden save method grants the user write permission to all the
+        folders, files and link files within the feed's folder. In addition, tests
+        whether the same permission is applied to all objects pointed by the linked
+        files under the feed's folder if they are owned by the feed's owner.
+        """
+        user = User.objects.get(username=self.username)
+        other_user = User.objects.get(username=self.other_username)
+        feed = Feed.objects.get(name=self.feed_name)
+        folder = feed.folder.children.first()
+
+        # create a file within the folder
+        storage_manager = connect_storage(settings)
+        file_path = f'{folder.path}/file.txt'
+        with io.StringIO("test file") as fi:
+            storage_manager.upload_obj(file_path, fi.read(),
+                                       content_type='text/plain')
+        f = UserFile(owner=user, parent_folder=folder)
+        f.fname.name = file_path
+        f.save()
+
+        # create a link file within the folder
+        lf = ChrisLinkFile(path=f'home/{self.username}/uploads', owner=user,
+                           parent_folder=folder)
+        lf.save(name=f'home_{self.username}_uploads')
+
+        # create a file within the pointed folder
+        pointed_folder, tf = ChrisFolder.objects.get_or_create(
+            path=f'home/{self.username}/uploads', owner=user)
+        file_path = f'{pointed_folder.path}/file1.txt'
+        with io.StringIO("test file") as fi:
+            storage_manager.upload_obj(file_path, fi.read(),
+                                       content_type='text/plain')
+        pf = UserFile(owner=user, parent_folder=pointed_folder)
+        pf.fname.name = file_path
+        pf.save()
+
+        perm = FeedUserPermission(feed=feed, user=other_user)
+        perm.save()
+
+        usernames = folder.shared_users.values_list('username', flat=True)
+        self.assertIn(self.other_username, usernames)
+
+        usernames = f.shared_users.values_list('username', flat=True)
+        self.assertIn(self.other_username, usernames)
+
+        usernames = lf.shared_users.values_list('username', flat=True)
+        self.assertIn(self.other_username, usernames)
+
+        usernames = pf.shared_users.values_list('username', flat=True)
+        self.assertIn(self.other_username, usernames)
+
+        ChrisFolder.objects.get(path=f'home/{self.username}').delete()
+
+    def test_delete(self):
+        """
+        Test whether overriden delete method removes the user's write permission from all
+        the folders, files and link files within the feed's folder. In addition, tests
+        whether the same permission is removed from all objects pointed by the linked
+        files under the feed's folder if they are owned by the feed's owner.
+        """
+        user = User.objects.get(username=self.username)
+        other_user = User.objects.get(username=self.other_username)
+        feed = Feed.objects.get(name=self.feed_name)
+        folder = feed.folder.children.first()
+
+        # create a file within the folder
+        storage_manager = connect_storage(settings)
+        file_path = f'{folder.path}/file.txt'
+        with io.StringIO("test file") as fi:
+            storage_manager.upload_obj(file_path, fi.read(),
+                                       content_type='text/plain')
+        f = UserFile(owner=user, parent_folder=folder)
+        f.fname.name = file_path
+        f.save()
+
+        # create a link file within the folder
+        lf = ChrisLinkFile(path=f'home/{self.username}/uploads', owner=user,
+                           parent_folder=folder)
+        lf.save(name=f'home_{self.username}_uploads')
+
+        # create a file within the pointed folder
+        pointed_folder, tf = ChrisFolder.objects.get_or_create(
+            path=f'home/{self.username}/uploads', owner=user)
+        file_path = f'{pointed_folder.path}/file1.txt'
+        with io.StringIO("test file") as fi:
+            storage_manager.upload_obj(file_path, fi.read(),
+                                       content_type='text/plain')
+        pf = UserFile(owner=user, parent_folder=pointed_folder)
+        pf.fname.name = file_path
+        pf.save()
+
+        perm = FeedUserPermission(feed=feed, user=other_user)
+        perm.save()
+        perm.delete()
+
+        usernames = folder.shared_users.values_list('username', flat=True)
+        self.assertNotIn(self.other_username, usernames)
+
+        usernames = f.shared_users.values_list('username', flat=True)
+        self.assertNotIn(self.other_username, usernames)
+
+        usernames = lf.shared_users.values_list('username', flat=True)
+        self.assertNotIn(self.other_username, usernames)
+
+        usernames = pf.shared_users.values_list('username', flat=True)
+        self.assertNotIn(self.other_username, usernames)
+
+        ChrisFolder.objects.get(path=f'home/{self.username}').delete()


### PR DESCRIPTION
1. Make delete requests to pfcon more robust and add periodic task to retry failed requests
2. Share filesystem objects pointed by link files under a feed's folder when the feed is shared