### PR TITLE
Replace healthcheck CMD with CMD-SHELL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
         aliases:
           - chrisdev.local  # hard-coded in chrisomatic/*.yml
     healthcheck:
-      test: [ "CMD", "sh", "-c", "curl -f http://localhost:8000/api/v1/users/ || exit 1" ]
+      test: [ "CMD-SHELL", "echo curl -f http://localhost:8000/api/v1/users/ || exit 1" ]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
More concise, and also happens to be a workaround for a Podman bug: https://github.com/containers/podman/issues/26519