### PR TITLE
Make is_staff user attribute read-only and  delete leftover file in storage when exception is raised

### DIFF
--- a/chris_backend/core/models.py
+++ b/chris_backend/core/models.py
@@ -581,12 +581,19 @@ class ChrisFile(models.Model):
 
     def save(self, *args, **kwargs):
         """
-        Overriden to ensure file paths never start or end with slashes.
+        Overriden to ensure file paths never start or end with slashes. Also, to delete
+        a leftover file in storage if any error happens when saving the file.
         """
         path = self.fname.name
         if path.startswith('/') or path.endswith('/'):
             raise ValueError('Paths starting or ending with slashes are not allowed.')
-        super(ChrisFile, self).save(*args, **kwargs)
+        try:
+            super(ChrisFile, self).save(*args, **kwargs)
+        except Exception:
+            storage_manager = connect_storage(settings)
+            if storage_manager.obj_exists(path):
+                storage_manager.delete_obj(path)
+            raise
 
     def move(self, new_path):
         """

--- a/chris_backend/users/serializers.py
+++ b/chris_backend/users/serializers.py
@@ -14,6 +14,7 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
                                    validators=[UniqueValidator(
                                        queryset=User.objects.all())])
     password = serializers.CharField(min_length=8, max_length=100, write_only=True)
+    is_staff = serializers.ReadOnlyField()
     groups = serializers.HyperlinkedIdentityField(view_name='user-group-list')
 
     class Meta:


### PR DESCRIPTION
1.  Delete leftover file in storage when an exception is raise while saving a file
2. Make is_staff user attribute read-only
Fix #630 and #638.