### PR TITLE
Add task to cancel plugin instances stuck in 'scheduled' status

### DIFF
--- a/chris_backend/core/celery.py
+++ b/chris_backend/core/celery.py
@@ -36,6 +36,8 @@ task_routes = {
         {'queue': 'periodic'},
     'plugininstances.tasks.cancel_plugin_instances_stuck_in_lock':
         {'queue': 'periodic'},
+    'plugininstances.tasks.cancel_plugin_instances_stuck_in_scheduled_status':
+        {'queue': 'periodic'},
     'plugininstances.tasks.delete_plugin_instances_jobs_from_remote':
         {'queue': 'periodic'},
     'pacsfiles.tasks.send_pacs_query': {'queue': 'main2'},
@@ -66,6 +68,10 @@ app.conf.beat_schedule = {
     },
     'cancel-plugin-instances-stuck-in-lock-every-7200-seconds': {
         'task': 'plugininstances.tasks.cancel_plugin_instances_stuck_in_lock',
+        'schedule': 7200.0,
+    },
+    'cancel-plugin-instances-stuck-in-scheduled_status-every-7200-seconds': {
+        'task': 'plugininstances.tasks.cancel_plugin_instances_stuck_in_scheduled_status',
         'schedule': 7200.0,
     },
     'delete-plugin-instances-jobs-from-remote-every-7200-seconds': {

--- a/chris_backend/pacsfiles/tasks.py
+++ b/chris_backend/pacsfiles/tasks.py
@@ -1,4 +1,5 @@
 
+import logging
 from typing import Optional
 
 from django.contrib.auth.models import User
@@ -8,14 +9,22 @@ from .models import PACSQuery
 from .serializers import PACSSeriesSerializer
 
 
+logger = logging.getLogger(__name__)
+
+
 @shared_task
 def send_pacs_query(pacs_query_id):
     """
     Send PACS query.
     """
     #from celery.contrib import rdb;rdb.set_trace()
-    pacs_query = PACSQuery.objects.get(pk=pacs_query_id)
-    pacs_query.send()
+    try:
+        pacs_query = PACSQuery.objects.get(pk=pacs_query_id)
+    except PACSQuery.DoesNotExist:
+        logger.error(f"PACS query with id {pacs_query_id} not found when running "
+                     f"send_pacs_query task.")
+    else:
+        pacs_query.send()
 
 
 @shared_task

--- a/chris_backend/plugininstances/models.py
+++ b/chris_backend/plugininstances/models.py
@@ -5,6 +5,7 @@ from django.db import models
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
 from django.conf import settings
+from django.utils import timezone
 
 import django_filters
 from django_filters.rest_framework import FilterSet
@@ -185,6 +186,17 @@ class PluginInstance(models.Model):
         the plugin instance object.
         """
         return str(self.output_folder.path)
+
+    def set_status(self, status):
+        self.status = status
+
+        if status == 'scheduled':
+            now = timezone.now()
+            self.start_date = now  # save scheduling date
+            self.end_date = now
+            self.save(update_fields=['start_date', 'end_date', 'status'])
+        else:
+            self.save(update_fields=['status'])
 
 
 @receiver(post_delete, sender=PluginInstance)

--- a/chris_backend/plugininstances/services/manager.py
+++ b/chris_backend/plugininstances/services/manager.py
@@ -185,12 +185,14 @@ class PluginInstanceManager(object):
             self.c_plugin_inst.status = 'started'
             self.c_plugin_inst.summary = self.get_job_status_summary()  # initial status
             self.c_plugin_inst.raw = json_zip2str(d_resp)
-            self.c_plugin_inst.save()
 
             # https://github.com/FNNDSC/ChRIS_ultron_backEnd/issues/408
             now = timezone.now()
             self.c_plugin_inst.start_date = now
             self.c_plugin_inst.end_date = now
+            self.c_plugin_inst.save()
+
+
 
     @staticmethod
     def _assemble_exec(selfpath: Optional[str], selfexec: str, execshell: Optional[str]) -> List[str]:


### PR DESCRIPTION
- Add task to cancel plugin instances stuck in 'scheduled' status
- Refactor code to update a plugin instance status
- Optimize some DB queries
Fix #653 