### PR TITLE
Remove compute_auth_token descriptor from a submitted Compute Resource form in the Admin site if value is a blank string

### DIFF
--- a/chris_backend/plugins/admin.py
+++ b/chris_backend/plugins/admin.py
@@ -28,7 +28,20 @@ plugin_readonly_fields = [fld.name for fld in Plugin._meta.fields if
                           fld.name != 'compute_resources']
 
 
+class ComputeResourceAdminForm(forms.ModelForm):
+
+    def clean(self):
+        """
+        Overriden to remove the compute_auth_token field if blank.
+        """
+        if 'compute_auth_token' in self.cleaned_data:
+            if self.cleaned_data['compute_auth_token'].strip() == '':
+                del self.cleaned_data['compute_auth_token']
+        return self.cleaned_data
+
+
 class ComputeResourceAdmin(admin.ModelAdmin):
+    form = ComputeResourceAdminForm
     readonly_fields = ['creation_date', 'modification_date']
     list_display = ('name', 'compute_url', 'compute_innetwork', 'description', 'id')
     list_filter = ['name', 'creation_date', 'modification_date']

--- a/chris_backend/plugins/tests/test_admin.py
+++ b/chris_backend/plugins/tests/test_admin.py
@@ -23,6 +23,44 @@ from plugins.models import PluginMeta, Plugin, PluginParameter
 COMPUTE_RESOURCE_URL = settings.COMPUTE_RESOURCE_URL
 
 
+class ComputeResourceFormTests(TestCase):
+    """
+    Test ComputeResourceAdminForm.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # avoid cluttered console output (for instance logging all the http requests)
+        logging.disable(logging.WARNING)
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        # re-enable logging
+        logging.disable(logging.NOTSET)
+
+    def setUp(self):
+        # avoid cluttered console output (for instance logging all the http requests)
+        logging.disable(logging.WARNING)
+
+        (self.compute_resource, tf) = pl_admin.ComputeResource.objects.get_or_create(
+            name="host", compute_url=COMPUTE_RESOURCE_URL)
+
+    def test_clean_removes_compute_auth_token_if_blank(self):
+        """
+        Test whether overriden clean method removes compute_auth_token descriptor from
+        the form if it is a blank string.
+        """
+        compute_resource_admin = pl_admin.ComputeResourceAdmin(pl_admin.ComputeResource,
+                                                               pl_admin.admin.site)
+        form = compute_resource_admin.form
+        form.instance = self.compute_resource
+        form.cleaned_data = {'compute_auth_token': ''}
+        cleaned_data = form.clean(form)
+        self.assertNotIn('compute_auth_token', cleaned_data)
+
+
 class ComputeResourceAdminTests(TestCase):
     """
     Test ComputeResourceAdmin.


### PR DESCRIPTION
Fix #556.