### PR TITLE
chore: migrate Orthanc image from jodogne to orthancteam

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -198,7 +198,7 @@ services:
         condition: service_healthy
 
   orthanc:
-    image: docker.io/jodogne/orthanc-plugins:1.12.3
+    image: docker.io/orthancteam/orthanc:25.12.3
     volumes:
       - ./orthanc.json:/etc/orthanc/orthanc.json:ro
       - orthanc:/var/lib/orthanc/db


### PR DESCRIPTION
Replace the deprecated jodogne/orthanc-plugins:1.12.3 image with the actively maintained orthancteam/orthanc:25.12.3. The jodogne/ namespace is no longer receiving security updates. The orthancteam/ image uses date-based tags, includes the same plugins, and is the official successor recommended by the Orthanc team.