### PR TITLE
Fix username not required in OpenAPI spec

### DIFF
--- a/chris_backend/config/settings/common.py
+++ b/chris_backend/config/settings/common.py
@@ -214,6 +214,7 @@ SPECTACULAR_SETTINGS = {
         'collectionjson.spectacular_hooks.postprocess_remove_collectionjson',
         'plugininstances.spectacular_hooks.additionalproperties_for_plugins_instances_create',
         'filebrowser.spectacular_hooks.nonrequired_fields',
+        'users.spectacular_hooks.users_get_username'
     ],
 
     'SCHEMA_PATH_PREFIX': '/api/v1/',

--- a/chris_backend/users/spectacular_hooks.py
+++ b/chris_backend/users/spectacular_hooks.py
@@ -1,0 +1,13 @@
+def users_get_username(result, **_kwargs):
+    """
+    This hook mutates the OpenAPI schema so that ``username`` is indicated as
+    required and readOnly.
+    """
+    user = result['components']['schemas']['User']
+    assert user['type'] == 'object'
+    assert 'username' in user['properties']
+
+    user['properties']['username']['readOnly'] = True
+    if 'username' not in user['required']:
+        user['required'].append('username')
+    return result


### PR DESCRIPTION
This PR description is over-descriptive, if tl;dr just check the title and diff.

Currently, the OpenAPI spec does not indicate that `username` is a required field of `User`. The type of `username` in generated client code is incorrectly `str | None` when it should be `str`.

This happens because `UserSerializer` is a single serializer class that is reused for both body and response for all of GET, POST, and PUT methods, despite how for most of them the schema are slightly different from one another.

- The serializer correctly indicates that `username` should not be a part of a PUT request.
- However, the serializer incorrectly indicates that `username` might not be a part of a GET/PUT/POST response.

This PR fixes the problem using a spectacular hook. I choose this solution instead of the alternatives:

- Creating separate serializers for the separate situations would have been more pedantically correct, but seems to go against the conventions of existing code.
- Using `@extend_schema` is generally preferred over spectacular hooks, however hooks can be more concise and separate concerns into separate files.

NOTE: In response to Codacy's concerns about `KeyError`, it would be pointless to check for these conditions because if the schema changes then we'll have to rewrite the hook function anyways.