### PR TITLE
dicomweb Phase B-3 — DICOM-tag query parser (dicomweb/query.py)

### DIFF
--- a/chris_backend/config/settings/benchmark.py
+++ b/chris_backend/config/settings/benchmark.py
@@ -22,3 +22,9 @@ DATABASES['default']['OPTIONS'] = {  # noqa: F405
         'timeout': int(os.getenv('CUBE_DB_POOL_TIMEOUT', '10')),
     }
 }
+# Re-apply the QIDO-RS fuzzy-matching similarity threshold GUC (the OPTIONS
+# reassignment above clobbers the merge done in local.py). See
+# DICOMWEB_FUZZY_THRESHOLD in common.py.
+DATABASES['default'].setdefault('OPTIONS', {})['options'] = (  # noqa: F405
+    f'-c pg_trgm.similarity_threshold={DICOMWEB_FUZZY_THRESHOLD}'  # noqa: F405
+)

--- a/chris_backend/config/settings/benchmark.py
+++ b/chris_backend/config/settings/benchmark.py
@@ -15,7 +15,7 @@ import os
 from .local import *  # noqa: F401,F403
 
 
-options = DATABASES['default'].setdefault('OPTIONS', {})
+options = DATABASES['default'].setdefault('OPTIONS', {})  # noqa: F405
 options['pool'] = {
     'min_size': int(os.getenv('CUBE_DB_POOL_MIN_SIZE', '2')),
     'max_size': int(os.getenv('CUBE_DB_POOL_MAX_SIZE', '10')),

--- a/chris_backend/config/settings/benchmark.py
+++ b/chris_backend/config/settings/benchmark.py
@@ -15,16 +15,9 @@ import os
 from .local import *  # noqa: F401,F403
 
 
-DATABASES['default']['OPTIONS'] = {  # noqa: F405
-    'pool': {
-        'min_size': int(os.getenv('CUBE_DB_POOL_MIN_SIZE', '2')),
-        'max_size': int(os.getenv('CUBE_DB_POOL_MAX_SIZE', '10')),
-        'timeout': int(os.getenv('CUBE_DB_POOL_TIMEOUT', '10')),
-    }
+options = DATABASES['default'].setdefault('OPTIONS', {})
+options['pool'] = {
+    'min_size': int(os.getenv('CUBE_DB_POOL_MIN_SIZE', '2')),
+    'max_size': int(os.getenv('CUBE_DB_POOL_MAX_SIZE', '10')),
+    'timeout': int(os.getenv('CUBE_DB_POOL_TIMEOUT', '10')),
 }
-# Re-apply the QIDO-RS fuzzy-matching similarity threshold GUC (the OPTIONS
-# reassignment above clobbers the merge done in local.py). See
-# DICOMWEB_FUZZY_THRESHOLD in common.py.
-DATABASES['default'].setdefault('OPTIONS', {})['options'] = (  # noqa: F405
-    f'-c pg_trgm.similarity_threshold={DICOMWEB_FUZZY_THRESHOLD}'  # noqa: F405
-)

--- a/chris_backend/config/settings/common.py
+++ b/chris_backend/config/settings/common.py
@@ -135,6 +135,15 @@ DATABASES = {
 DICOMWEB_FUZZY_THRESHOLD = env.float('DICOMWEB_FUZZY_THRESHOLD', 0.3)
 
 
+def apply_dicomweb_fuzzy_threshold(database, threshold=DICOMWEB_FUZZY_THRESHOLD):
+    """Merge the QIDO-RS fuzzy-matching similarity threshold into a database's
+    connection ``OPTIONS`` as a per-connection GUC, preserving any ``pool`` (or
+    other) config already present.
+    """
+    options = database.setdefault('OPTIONS', {})
+    options['options'] = f'-c pg_trgm.similarity_threshold={threshold}'
+
+
 # Password validation
 # https://docs.djangoproject.com/en/5.1/ref/settings/#auth-password-validators
 

--- a/chris_backend/config/settings/common.py
+++ b/chris_backend/config/settings/common.py
@@ -36,6 +36,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.postgres',
     'django_filters',
     'django_celery_beat',
     'rest_framework',
@@ -125,6 +126,13 @@ DATABASES = {
         'ENGINE': 'django.db.backends.postgresql',
     }
 }
+
+# QIDO-RS fuzzy Person-Name matching (PS3.18 §8.3.4.2 / PS3.4 §C.2.2.2.1.1).
+# Backed by pg_trgm's '%' similarity operator; this value is applied as the
+# session GUC pg_trgm.similarity_threshold per DB connection (see the DATABASES
+# OPTIONS in the environment-specific settings). Valid range 0.0–1.0 (higher =
+# stricter); Postgres' pg_trgm default is 0.3.
+DICOMWEB_FUZZY_THRESHOLD = env.float('DICOMWEB_FUZZY_THRESHOLD', 0.3)
 
 
 # Password validation

--- a/chris_backend/config/settings/local.py
+++ b/chris_backend/config/settings/local.py
@@ -152,7 +152,7 @@ DATABASES['default']['PORT'] = '5432'
 DATABASES['default']['OPTIONS'] = {'pool': {'min_size': 1, 'max_size': 2, 'timeout': 10}}
 # Apply the QIDO-RS fuzzy-matching similarity threshold GUC (see common.py),
 # whether or not the connection pool branch above ran.
-apply_dicomweb_fuzzy_threshold(DATABASES['default'])
+apply_dicomweb_fuzzy_threshold(DATABASES['default'])  # noqa: F405
 
 # Mail settings
 # ------------------------------------------------------------------------------

--- a/chris_backend/config/settings/local.py
+++ b/chris_backend/config/settings/local.py
@@ -150,12 +150,9 @@ DATABASES['default']['TEST'] = {'NAME': 'test_chris_dev'}
 DATABASES['default']['HOST'] = 'chris_dev_db'
 DATABASES['default']['PORT'] = '5432'
 DATABASES['default']['OPTIONS'] = {'pool': {'min_size': 1, 'max_size': 2, 'timeout': 10}}
-# Apply the QIDO-RS fuzzy-matching similarity threshold as a per-connection GUC
-# (see DICOMWEB_FUZZY_THRESHOLD in common.py). Merge into OPTIONS so the pool
-# config above is preserved.
-DATABASES['default'].setdefault('OPTIONS', {})['options'] = (  # noqa: F405
-    f'-c pg_trgm.similarity_threshold={DICOMWEB_FUZZY_THRESHOLD}'  # noqa: F405
-)
+# Apply the QIDO-RS fuzzy-matching similarity threshold GUC (see common.py),
+# whether or not the connection pool branch above ran.
+apply_dicomweb_fuzzy_threshold(DATABASES['default'])
 
 # Mail settings
 # ------------------------------------------------------------------------------

--- a/chris_backend/config/settings/local.py
+++ b/chris_backend/config/settings/local.py
@@ -150,6 +150,12 @@ DATABASES['default']['TEST'] = {'NAME': 'test_chris_dev'}
 DATABASES['default']['HOST'] = 'chris_dev_db'
 DATABASES['default']['PORT'] = '5432'
 DATABASES['default']['OPTIONS'] = {'pool': {'min_size': 1, 'max_size': 2, 'timeout': 10}}
+# Apply the QIDO-RS fuzzy-matching similarity threshold as a per-connection GUC
+# (see DICOMWEB_FUZZY_THRESHOLD in common.py). Merge into OPTIONS so the pool
+# config above is preserved.
+DATABASES['default'].setdefault('OPTIONS', {})['options'] = (  # noqa: F405
+    f'-c pg_trgm.similarity_threshold={DICOMWEB_FUZZY_THRESHOLD}'  # noqa: F405
+)
 
 # Mail settings
 # ------------------------------------------------------------------------------

--- a/chris_backend/config/settings/production.py
+++ b/chris_backend/config/settings/production.py
@@ -65,6 +65,13 @@ if DATABASE_CONN_POOL:
                                                 'max_size': DATABASE_CONN_POOL_MAX_SIZE,
                                                 'timeout': DATABASE_CONN_POOL_TIMEOUT}}
 
+# Apply the QIDO-RS fuzzy-matching similarity threshold as a per-connection GUC
+# (see DICOMWEB_FUZZY_THRESHOLD in common.py). Merge into OPTIONS unconditionally
+# so it is set whether or not the connection pool branch above ran.
+DATABASES['default'].setdefault('OPTIONS', {})['options'] = (  # noqa: F405
+    f'-c pg_trgm.similarity_threshold={DICOMWEB_FUZZY_THRESHOLD}'  # noqa: F405
+)
+
 
 # STORAGE CONFIGURATION
 # ------------------------------------------------------------------------------

--- a/chris_backend/config/settings/production.py
+++ b/chris_backend/config/settings/production.py
@@ -65,12 +65,9 @@ if DATABASE_CONN_POOL:
                                                 'max_size': DATABASE_CONN_POOL_MAX_SIZE,
                                                 'timeout': DATABASE_CONN_POOL_TIMEOUT}}
 
-# Apply the QIDO-RS fuzzy-matching similarity threshold as a per-connection GUC
-# (see DICOMWEB_FUZZY_THRESHOLD in common.py). Merge into OPTIONS unconditionally
-# so it is set whether or not the connection pool branch above ran.
-DATABASES['default'].setdefault('OPTIONS', {})['options'] = (  # noqa: F405
-    f'-c pg_trgm.similarity_threshold={DICOMWEB_FUZZY_THRESHOLD}'  # noqa: F405
-)
+# Apply the QIDO-RS fuzzy-matching similarity threshold GUC (see common.py),
+# whether or not the connection pool branch above ran.
+apply_dicomweb_fuzzy_threshold(DATABASES['default'])  # noqa: F405
 
 
 # STORAGE CONFIGURATION

--- a/chris_backend/dicomweb/query.py
+++ b/chris_backend/dicomweb/query.py
@@ -1,0 +1,224 @@
+"""
+DICOM-tag query parser for QIDO-RS (PS3.18 §F.7).
+
+Translates URL query parameters (hex tags or DICOM keywords) into Django ORM
+filter expressions. Handles: multi-value OR, date ranges, wildcards, limit/offset.
+
+Usage::
+
+    from dicomweb.query import QueryFilter, TAG_MAP_SERIES
+
+    qf = QueryFilter(TAG_MAP_SERIES)
+    qs = qf.apply(PACSSeries.objects.all(), request.query_params)
+    page, total, limit = qf.paginate(qs, request.query_params)
+"""
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Optional
+
+import pydicom.datadict
+from django.db.models import Q, QuerySet
+from django.http import QueryDict
+
+
+# ---------------------------------------------------------------------------
+# Tag descriptor types
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ModelField:
+    orm_path: str       # e.g. 'PatientName' or 'series__StudyInstanceUID'
+    vr: str             # DICOM VR ('PN', 'DA', 'UI', 'CS', ...)
+    range_: bool = False   # DA/TM range syntax supported
+    wildcard: bool = False  # wildcard ('*' / '?') supported
+
+
+@dataclass
+class Aggregation:
+    """Tags handled by view-level .annotate()/.filter(); skipped here."""
+    name: str
+
+
+# ---------------------------------------------------------------------------
+# Static tag maps
+# ---------------------------------------------------------------------------
+
+TAG_MAP_STUDY = {
+    '00100010': ModelField('PatientName', vr='PN', wildcard=True),
+    '00100020': ModelField('PatientID', vr='LO', wildcard=True),
+    '00100030': ModelField('PatientBirthDate', vr='DA', range_=True),
+    '00100040': ModelField('PatientSex', vr='CS'),
+    '0020000D': ModelField('StudyInstanceUID', vr='UI'),
+    '00080020': ModelField('StudyDate', vr='DA', range_=True),
+    '00080030': ModelField('StudyTime', vr='TM', range_=True),
+    '00080050': ModelField('AccessionNumber', vr='SH', wildcard=True),
+    '00081030': ModelField('StudyDescription', vr='LO', wildcard=True),
+    # Aggregation tags — handled in view, not here
+    '00080061': Aggregation('ModalitiesInStudy'),
+    '00201206': Aggregation('NumberOfStudyRelatedSeries'),
+    '00201208': Aggregation('NumberOfStudyRelatedInstances'),
+}
+
+TAG_MAP_SERIES = {
+    '0020000E': ModelField('SeriesInstanceUID', vr='UI'),
+    '00200011': ModelField('SeriesNumber', vr='IS'),
+    '00080060': ModelField('Modality', vr='CS'),
+    '0008103E': ModelField('SeriesDescription', vr='LO', wildcard=True),
+    '00180015': ModelField('BodyPartExamined', vr='CS'),
+    '00080070': ModelField('Manufacturer', vr='LO', wildcard=True),
+    '00181030': ModelField('ProtocolName', vr='LO', wildcard=True),
+    # Study-level pass-through
+    '0020000D': ModelField('StudyInstanceUID', vr='UI'),
+    '00100010': ModelField('PatientName', vr='PN', wildcard=True),
+    '00100020': ModelField('PatientID', vr='LO'),
+}
+
+TAG_MAP_INSTANCE = {
+    '00080018': ModelField('SOPInstanceUID', vr='UI'),
+    '00080016': ModelField('SOPClassUID', vr='UI'),
+    '00200013': ModelField('InstanceNumber', vr='IS'),
+    '00280010': ModelField('Rows', vr='US'),
+    '00280011': ModelField('Columns', vr='US'),
+    '00280100': ModelField('BitsAllocated', vr='US'),
+    '00280008': ModelField('NumberOfFrames', vr='IS'),
+    # Series pass-through
+    '0020000E': ModelField('series__SeriesInstanceUID', vr='UI'),
+    '0020000D': ModelField('series__StudyInstanceUID', vr='UI'),
+}
+
+
+# ---------------------------------------------------------------------------
+# QueryFilter
+# ---------------------------------------------------------------------------
+
+_RESERVED_PARAMS = frozenset({'limit', 'offset', 'includefield', 'fuzzymatching', 'orderby'})
+
+
+class QueryFilter:
+    """
+    Translates QIDO-RS URL parameters into ORM filter expressions.
+
+    Unsupported tags are silently dropped (PS3.18 §F.7: servers may ignore
+    unsupported match attributes).
+    """
+    HARD_LIMIT = 5000
+    DEFAULT_LIMIT = 50
+
+    def __init__(self, tag_map: dict):
+        self.tag_map = tag_map
+        self._kw_to_hex = {}
+        for hex_tag in tag_map:
+            if len(hex_tag) != 8:
+                continue
+            try:
+                kw = pydicom.datadict.keyword_for_tag(int(hex_tag, 16))
+                if kw:
+                    self._kw_to_hex[kw] = hex_tag
+            except Exception:
+                pass
+
+    def apply(self, qs: QuerySet, params) -> QuerySet:
+        """Apply DICOM match parameters from ``params`` to ``qs``."""
+        if isinstance(params, QueryDict):
+            items = params.items()
+        else:
+            items = params.items() if hasattr(params, 'items') else params
+
+        for key, value in items:
+            if key in _RESERVED_PARAMS:
+                continue
+            if not value:
+                # PS3.18 §F.7: empty value → no restriction on that attribute
+                continue
+            hex_tag = self._resolve_tag(key)
+            if hex_tag is None:
+                continue
+            descriptor = self.tag_map.get(hex_tag)
+            if descriptor is None or isinstance(descriptor, Aggregation):
+                continue
+            qs = self._apply_field(qs, descriptor, value)
+        return qs
+
+    def paginate(self, qs: QuerySet, params):
+        """Return (page_qs, total_count, effective_limit)."""
+        raw_limit = params.get('limit', self.DEFAULT_LIMIT) if hasattr(params, 'get') else self.DEFAULT_LIMIT
+        raw_offset = params.get('offset', 0) if hasattr(params, 'get') else 0
+        try:
+            limit = min(int(raw_limit), self.HARD_LIMIT)
+        except (TypeError, ValueError):
+            limit = self.DEFAULT_LIMIT
+        try:
+            offset = max(int(raw_offset), 0)
+        except (TypeError, ValueError):
+            offset = 0
+        total = qs.count()
+        return qs[offset:offset + limit], total, limit
+
+    # ── Private helpers ──────────────────────────────────────────────────────
+
+    def _resolve_tag(self, key: str) -> Optional[str]:
+        """Return 8-hex-char tag from either hex form or DICOM keyword."""
+        upper = key.upper()
+        if len(upper) == 8 and all(c in '0123456789ABCDEF' for c in upper):
+            return upper
+        return self._kw_to_hex.get(key)  # case-sensitive keyword lookup
+
+    def _apply_field(self, qs: QuerySet, descriptor: ModelField, raw_value: str) -> QuerySet:
+        field = descriptor.orm_path
+        vr = descriptor.vr
+        values = raw_value.split(',')  # multi-value → OR semantics
+
+        # Date/time range: only activate for DA/TM VRs with a single value containing '-'
+        if vr in ('DA', 'TM', 'DT') and descriptor.range_ and '-' in raw_value and len(values) == 1:
+            return self._apply_range(qs, field, vr, raw_value)
+
+        q = Q()
+        for v in values:
+            if descriptor.wildcard and ('*' in v or '?' in v):
+                like_val = v.replace('*', '%').replace('?', '_')
+                q |= Q(**{f'{field}__icontains': like_val.strip('%_')}) if like_val in ('%', '_') else Q(**{f'{field}__iregex': _like_to_regex(like_val)})
+            elif vr == 'PN':
+                # PN: stored as 'FAMILY^GIVEN'; support exact or alphabetic-component prefix
+                q |= Q(**{f'{field}__iexact': v}) | Q(**{f'{field}__istartswith': v})
+            else:
+                q |= Q(**{f'{field}': v})
+        return qs.filter(q)
+
+    def _apply_range(self, qs: QuerySet, field: str, vr: str, raw_value: str) -> QuerySet:
+        parts = raw_value.split('-', 1)
+        start_str = parts[0].strip()
+        end_str = parts[1].strip() if len(parts) > 1 else ''
+        start = _parse_da(start_str) if start_str else None
+        end = _parse_da(end_str) if end_str else None
+        if start:
+            qs = qs.filter(**{f'{field}__gte': start})
+        if end:
+            qs = qs.filter(**{f'{field}__lte': end})
+        return qs
+
+
+# ---------------------------------------------------------------------------
+# Internal utilities
+# ---------------------------------------------------------------------------
+
+def _parse_da(s: str):
+    """Parse DICOM DA string (YYYYMMDD) to Python date, or None on failure."""
+    try:
+        return datetime.strptime(s[:8], '%Y%m%d').date()
+    except (ValueError, TypeError):
+        return None
+
+
+def _like_to_regex(like_val: str) -> str:
+    """Convert SQL LIKE pattern (with % and _) to a Python regex string."""
+    import re
+    parts = re.split(r'([%_])', like_val)
+    result = []
+    for part in parts:
+        if part == '%':
+            result.append('.*')
+        elif part == '_':
+            result.append('.')
+        else:
+            result.append(re.escape(part))
+    return ''.join(result)

--- a/chris_backend/dicomweb/query.py
+++ b/chris_backend/dicomweb/query.py
@@ -138,6 +138,11 @@ class MultipleValue[T]:
 
 
 @dataclass
+class UIDListValue:
+    values: list[str]
+
+
+@dataclass
 class Attribute:
     keyword: str
     orm_field: str = ""         # Will default to keyword if unset
@@ -174,6 +179,9 @@ class Attribute:
             return False
         return self.vm != '1'
 
+    def cap_uid_list(self) -> bool:
+        return self.vr in UID_LIST_VRS
+
     def parse(self, value: str, multi_value: bool = False) -> Any:
         if value == '':
             return UniversalValue()
@@ -181,12 +189,18 @@ class Attribute:
             return EmptyValue()
         if self.cap_range() and "-" in value:
             return self.parse_range(value)
-        if self.vr in UID_LIST_VRS or (self.cap_multi_value() and multi_value):
+        if self.cap_multi_value() and multi_value:
             parsed_value = self.parse_multiple(value)
             length = len(parsed_value.values)
             if length == 1:
                 return parsed_value.values[0]
             return parsed_value
+        if self.cap_uid_list():
+            uid_list_value = self.parse_uid_list(value)
+            length = len(uid_list_value.values)
+            if length == 1:
+                return uid_list_value.values[0]
+            return uid_list_value
         return self.parse_single(value)
 
     def parse_single(self, value: str) -> Any:
@@ -207,6 +221,9 @@ class Attribute:
 
     def parse_multiple(self, value: str) -> MultipleValue:
         return MultipleValue([self.parse_single(v) for v in re.split(r'[\\,]', value) if len(v) > 0])
+
+    def parse_uid_list(self, value: str) -> UIDListValue:
+        return UIDListValue([self.parse_single(v) for v in re.split(',', value) if len(v) > 0])
 
 
 # ---------------------------------------------------------------------------
@@ -304,7 +321,13 @@ class QueryFilter:
                         q |= range_q
                         continue
                     case MultipleValue(multi_values):
-                        q |= Q(**{f'{attribute.orm_field}__in': multi_values})
+                        multi_value_q = Q()
+                        for value in multi_values:
+                            multi_value_q &= Q(**{f'{attribute.orm_field}__contains': value})
+                        q |= multi_value_q
+                        continue
+                    case UIDListValue(uid_list):
+                        q |= Q(**{f'{attribute.orm_field}__in': uid_list})
                         continue
                     case UniversalValue():
                         # PS3.4 §C.2.2.2.3 Universal Matching

--- a/chris_backend/dicomweb/query.py
+++ b/chris_backend/dicomweb/query.py
@@ -1,8 +1,10 @@
 """
-DICOM-tag query parser for QIDO-RS (PS3.18 §F.7).
+DICOM-tag query parser for QIDO-RS (PS3.18 §10.6.1.2 "Query Parameters"; matching
+semantics per §8.3.4 and PS3.4 §C.2.2.2).
 
 Translates URL query parameters (hex tags or DICOM keywords) into Django ORM
-filter expressions. Handles: multi-value OR, date ranges, wildcards, limit/offset.
+filter expressions. Handles: multi-value OR, date ranges, wildcards, fuzzy
+Person-Name matching (§8.3.4.2), and limit/offset pagination (§8.3.4.4).
 
 Usage::
 
@@ -31,6 +33,7 @@ class ModelField:
     vr: str             # DICOM VR ('PN', 'DA', 'UI', 'CS', ...)
     range_: bool = False   # DA/TM range syntax supported
     wildcard: bool = False  # wildcard ('*' / '?') supported
+    fuzzy: bool = False  # eligible for fuzzy PN matching (PS3.18 §8.3.4.2)
 
 
 @dataclass
@@ -44,7 +47,7 @@ class Aggregation:
 # ---------------------------------------------------------------------------
 
 TAG_MAP_STUDY = {
-    '00100010': ModelField('PatientName', vr='PN', wildcard=True),
+    '00100010': ModelField('PatientName', vr='PN', wildcard=True, fuzzy=True),
     '00100020': ModelField('PatientID', vr='LO', wildcard=True),
     '00100030': ModelField('PatientBirthDate', vr='DA', range_=True),
     '00100040': ModelField('PatientSex', vr='CS'),
@@ -69,7 +72,7 @@ TAG_MAP_SERIES = {
     '00181030': ModelField('ProtocolName', vr='LO', wildcard=True),
     # Study-level pass-through
     '0020000D': ModelField('StudyInstanceUID', vr='UI'),
-    '00100010': ModelField('PatientName', vr='PN', wildcard=True),
+    '00100010': ModelField('PatientName', vr='PN', wildcard=True, fuzzy=True),
     '00100020': ModelField('PatientID', vr='LO'),
 }
 
@@ -119,6 +122,11 @@ class QueryFilter:
 
     def apply(self, qs: QuerySet, params) -> QuerySet:
         """Apply DICOM match parameters from ``params`` to ``qs``."""
+        # Fuzzy Person-Name matching is a request-wide modifier, not a match key
+        # (PS3.18 §8.3.4.2). Resolve it once up front so it can influence PN terms.
+        fuzzy = (str(params.get('fuzzymatching', '')).lower() in ('true', '1', 'yes')
+                 if hasattr(params, 'get') else False)
+
         if isinstance(params, QueryDict):
             items = params.items()
         else:
@@ -128,7 +136,7 @@ class QueryFilter:
             if key in _RESERVED_PARAMS:
                 continue
             if not value:
-                # PS3.18 §F.7: empty value → no restriction on that attribute
+                # §8.3.4.1 / PS3.4 §C.2.2.2: empty value → no restriction on that attribute
                 continue
             hex_tag = self._resolve_tag(key)
             if hex_tag is None:
@@ -136,7 +144,7 @@ class QueryFilter:
             descriptor = self.tag_map.get(hex_tag)
             if descriptor is None or isinstance(descriptor, Aggregation):
                 continue
-            qs = self._apply_field(qs, descriptor, value)
+            qs = self._apply_field(qs, descriptor, value, fuzzy)
         return qs
 
     def paginate(self, qs: QuerySet, params):
@@ -163,7 +171,8 @@ class QueryFilter:
             return upper
         return self._kw_to_hex.get(key)  # case-sensitive keyword lookup
 
-    def _apply_field(self, qs: QuerySet, descriptor: ModelField, raw_value: str) -> QuerySet:
+    def _apply_field(self, qs: QuerySet, descriptor: ModelField, raw_value: str,
+                     fuzzy: bool = False) -> QuerySet:
         field = descriptor.orm_path
         vr = descriptor.vr
         values = raw_value.split(',')  # multi-value → OR semantics
@@ -171,6 +180,12 @@ class QueryFilter:
         # Date/time range: only activate for DA/TM VRs with a single value containing '-'
         if vr in ('DA', 'TM', 'DT') and descriptor.range_ and '-' in raw_value and len(values) == 1:
             return self._apply_range(qs, field, vr, raw_value)
+
+        # Fuzzy Person-Name matching (PS3.18 §8.3.4.2). Applies only to fuzzy-eligible
+        # PN attributes when fuzzymatching=true and no wildcard is present — an explicit
+        # wildcard takes precedence and falls through to the wildcard path below.
+        if fuzzy and descriptor.fuzzy and '*' not in raw_value and '?' not in raw_value:
+            return self._apply_fuzzy(qs, field, values)
 
         q = Q()
         for v in values:
@@ -182,6 +197,19 @@ class QueryFilter:
                 q |= Q(**{f'{field}__iexact': v}) | Q(**{f'{field}__istartswith': v})
             else:
                 q |= Q(**{f'{field}': v})
+        return qs.filter(q)
+
+    def _apply_fuzzy(self, qs: QuerySet, field: str, values) -> QuerySet:
+        """Fuzzy PN match via pg_trgm's ``%`` operator (Django ``__trigram_similar``).
+
+        GIN-index-backed. The match threshold is Postgres' session GUC
+        ``pg_trgm.similarity_threshold``, set per connection from
+        ``settings.DICOMWEB_FUZZY_THRESHOLD`` (see the DATABASES OPTIONS in the
+        environment settings). Multi-value → OR (PS3.18 §8.3.4.2, PS3.4 §C.2.2.2.1.1).
+        """
+        q = Q()
+        for v in values:
+            q |= Q(**{f'{field}__trigram_similar': v})
         return qs.filter(q)
 
     def _apply_range(self, qs: QuerySet, field: str, vr: str, raw_value: str) -> QuerySet:

--- a/chris_backend/dicomweb/query.py
+++ b/chris_backend/dicomweb/query.py
@@ -370,7 +370,7 @@ def _is_text_column(model, orm_field: str) -> bool:
 
 
 def _parse_da(s: str):
-    """Parse DICOM DA string (YYYYMMDD) to Python date, or None on failure."""
+    """Parse DICOM DA string (YYYYMMDD) to Python date; raises ValueError on failure."""
     try:
         return datetime.strptime(s[:8], '%Y%m%d').date()
     except (ValueError, TypeError):
@@ -379,7 +379,7 @@ def _parse_da(s: str):
 
 def _parse_tm(s: str):
     """Parse a DICOM TM string (HHMMSS[.ffffff], truncated forms allowed) to a
-    Python time, or None on failure."""
+    Python time; raises ValueError on failure."""
     raw = s.split('.', 1)[0]
     fmt = {6: '%H%M%S', 4: '%H%M', 2: '%H'}.get(len(raw))
     if fmt is None:
@@ -392,7 +392,7 @@ def _parse_tm(s: str):
 
 def _parse_dt(s: str):
     """Parse a DICOM DT string (YYYYMMDD[HHMMSS], truncated forms allowed) to a
-    Python datetime, or None on failure."""
+    Python datetime; raises ValueError on failure."""
     raw = s.split('.', 1)[0]
     for fmt in ('%Y%m%d', '%Y%m%d%H', '%Y%m%d%H%M', '%Y%m%d%H%M%S'):
         try:
@@ -403,8 +403,9 @@ def _parse_dt(s: str):
 
 
 def _parse_temporal(vr: str, s: str):
-    """Parse a DICOM DA/TM/DT string into its native type (date/time/datetime),
-    or None. Dispatches on VR so range and exact matching coerce correctly."""
+    """Parse a DICOM DA/TM/DT string into its native type (date/time/datetime).
+    Dispatches on VR so range and exact matching coerce correctly. Raises
+    ValueError on malformed input, or TypeError on an unsupported VR."""
     if vr == 'DA':
         return _parse_da(s)
     if vr == 'TM':

--- a/chris_backend/dicomweb/query.py
+++ b/chris_backend/dicomweb/query.py
@@ -14,88 +14,216 @@ Usage::
     qs = qf.apply(PACSSeries.objects.all(), request.query_params)
     page, total, limit = qf.paginate(qs, request.query_params)
 """
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime
-from typing import Optional
+from typing import Self, Optional, Literal, Any, Union
 
 import pydicom.datadict
 from django.db.models import Q, QuerySet
 from django.http import QueryDict
 
 
+# Alias
+Tag = pydicom.tag.Tag
+
+# reserved words for search query parameters
+_SEARCH_PARAMS = frozenset({
+    'limit', 'offset', 'includefield', 'fuzzymatching',
+    'orderby', 'emptyvaluematching', 'multiplevaluematching'
+})
+
+
+@dataclass
+class SearchQuery:
+    match: dict[Tag, list[str]]
+    fuzzymatching: bool = False
+    includefield: Optional[Union[list[Tag], Literal['all']]] = None
+    limit: Optional[int] = None
+    offset: Optional[int] = None
+    emptyvaluematching: bool = False
+    multiplevaluematching: bool = False
+
+    @staticmethod
+    def _parse_bool(value: str) -> bool:
+        return value.lower() in ('true', '1', 'yes')
+
+    @classmethod
+    def from_query_dict(cls, params: QueryDict) -> Self:
+        # Split the query parameters into matches and search parameters
+        match_pairs = {}
+        for param in params:
+            if param not in _SEARCH_PARAMS:
+                try:
+                    tag = Tag(param)
+                except (ValueError, OverflowError):
+                    continue
+                match_pairs[tag] = params.getlist(param)
+
+        search_options = {}
+        if 'includefield' in params:
+            # includefield can be passed multiple times and/or be a
+            # comma-separated list. It may also include the special
+            # 'all' value.
+            includefield = []
+            for item in params.getlist('includefield'):
+                includefield.extend(item.split(","))
+            if 'all' in includefield:
+                search_options['includefield'] = 'all'
+            else:
+                _includefield = []
+                for val in includefield:
+                    try:
+                        tag = Tag(val)
+                    except (ValueError, OverflowError):
+                        continue
+                    _includefield.append(tag)
+                search_options['includefield'] = _includefield
+        if (limit := params.get('limit')) is not None:
+            search_options['limit'] = int(limit)
+        if (offset := params.get('offset')) is not None:
+            search_options['offset'] = int(offset)
+        for field in ['fuzzymatching', 'emptyvaluematching', 'multiplevaluematching']:
+            if (field_value := params.get(field)) is not None:
+                search_options[field] = cls._parse_bool(field_value)
+
+        return cls(
+            match = match_pairs,
+            **search_options,
+        )
+
+
+
+# Matching types for VRs
+WILDCARD_VRS = frozenset({'AE', 'CS', 'LO', 'LT', 'PN', 'SH', 'ST', 'UC',
+                          'UR', 'UT'})
+MULTI_VALUE_VRS = frozenset({'AE', 'AS', 'AT', 'CS', 'LO', 'PN', 'SH', 'UC'})
+RANGE_VRS = frozenset({'DA', 'TM', 'DT'})
+UID_LIST_VRS = frozenset({'UI'})
+
 # ---------------------------------------------------------------------------
 # Tag descriptor types
 # ---------------------------------------------------------------------------
 
+
 @dataclass
-class ModelField:
-    orm_path: str       # e.g. 'PatientName' or 'series__StudyInstanceUID'
-    vr: str             # DICOM VR ('PN', 'DA', 'UI', 'CS', ...)
-    range_: bool = False   # DA/TM range syntax supported
-    wildcard: bool = False  # wildcard ('*' / '?') supported
-    fuzzy: bool = False  # eligible for fuzzy PN matching (PS3.18 §8.3.4.2)
+class RangeValue[T]:
+    start: T
+    end: T
+
+@dataclass
+class MultipleValue[T]:
+    values: list[T]
 
 
 @dataclass
-class Aggregation:
-    """Tags handled by view-level .annotate()/.filter(); skipped here."""
-    name: str
+class Attribute:
+    keyword: str
+    orm_field: str = ""         # Will default to keyword if unset
+    fuzzy: bool = False # eligible for fuzzy PN matching (PS3.18 §8.3.4.2)
+    fuzzy_lookup: str = "trigram_similar"
+    tag: Optional[Tag] = None
+    vr: Optional[str] = None
+    vm: Optional[str] = None
+
+    def __post_init__(self):
+        if self.orm_field == "":
+            self.orm_field = self.keyword
+        if self.tag is None:
+            self.tag = pydicom.tag.Tag(self.keyword)
+        if self.vr is None:
+            self.vr = pydicom.datadict.dictionary_VR(self.tag)
+        if self.vm is None:
+            self.vm = pydicom.datadict.dictionary_VM(self.tag)
+
+    def cap_wildcard(self) -> bool:
+        return self.vr in WILDCARD_VRS
+
+    def cap_range(self) -> bool:
+        return self.vr in RANGE_VRS
+
+    def cap_multi_value(self) -> bool:
+        # PS3.4 §C.2.2.2.8
+        if self.vr not in MULTI_VALUE_VRS:
+            return False
+        return self.vm != '1'
+
+    def parse(self, value: str, multi_value: bool=False) -> Any:
+        if self.cap_range() and "-" in value:
+            return self.parse_range(value)
+        if self.cap_multi_value() and multi_value:
+            parsed_value = self.parse_multiple(value)
+            if len(parsed_value.values) == 1:
+                return parsed_value.values[0]
+            return parsed_value
+        return self.parse_single(value)
+
+    def parse_single(self, value: str) -> Any:
+        """Parse a single value from a query string. For range values, use parse_range."""
+        if self.vr in ['DA', 'DT', 'TM']:
+            return _parse_temporal(self.vr, value)
+        return value
+
+    def parse_range(self, value: str) -> RangeValue:
+        if '-' not in value:
+            raise ValueError(f'Invalid range value: {value}')
+        start, end = value.split('-', maxsplit=1)
+        return RangeValue(self.parse_single(start), self.parse_single(end))
+
+    def parse_multiple(self, value: str) -> MultipleValue:
+        import re
+        return MultipleValue([self.parse_single(v) for v in re.split(r'[\\,]', value)])
 
 
 # ---------------------------------------------------------------------------
-# Static tag maps
+# Supported Query fields
 # ---------------------------------------------------------------------------
 
-TAG_MAP_STUDY = {
-    '00100010': ModelField('PatientName', vr='PN', wildcard=True, fuzzy=True),
-    '00100020': ModelField('PatientID', vr='LO', wildcard=True),
-    '00100030': ModelField('PatientBirthDate', vr='DA', range_=True),
-    '00100040': ModelField('PatientSex', vr='CS'),
-    '0020000D': ModelField('StudyInstanceUID', vr='UI'),
-    '00080020': ModelField('StudyDate', vr='DA', range_=True),
-    '00080030': ModelField('StudyTime', vr='TM', range_=True),
-    '00080050': ModelField('AccessionNumber', vr='SH', wildcard=True),
-    '00081030': ModelField('StudyDescription', vr='LO', wildcard=True),
-    # Aggregation tags — handled in view, not here
-    '00080061': Aggregation('ModalitiesInStudy'),
-    '00201206': Aggregation('NumberOfStudyRelatedSeries'),
-    '00201208': Aggregation('NumberOfStudyRelatedInstances'),
-}
+QUERY_FIELDS_STUDY = [
+        Attribute('PatientName', fuzzy=True),
+        Attribute('PatientID'),
+        Attribute('PatientBirthDate'),
+        Attribute('PatientSex'),
+        Attribute('StudyInstanceUID'),
+        Attribute('StudyDate'),
+        Attribute('StudyTime'),
+        Attribute('AccessionNumber'),
+        Attribute('StudyDescription'),
+        # Attribute('ModalitiesInStudy', aggregation=True),
+        Attribute('NumberOfStudyRelatedSeries'),
+        Attribute('NumberOfStudyRelatedInstances'),
+    ]
 
-TAG_MAP_SERIES = {
-    '0020000E': ModelField('SeriesInstanceUID', vr='UI'),
-    '00200011': ModelField('SeriesNumber', vr='IS'),
-    '00080060': ModelField('Modality', vr='CS'),
-    '0008103E': ModelField('SeriesDescription', vr='LO', wildcard=True),
-    '00180015': ModelField('BodyPartExamined', vr='CS'),
-    '00080070': ModelField('Manufacturer', vr='LO', wildcard=True),
-    '00181030': ModelField('ProtocolName', vr='LO', wildcard=True),
+QUERY_FIELDS_SERIES = [
+    Attribute('SeriesInstanceUID'),
+    Attribute('SeriesNumber'),
+    Attribute('Modality'),
+    Attribute('SeriesDescription'),
+    Attribute('BodyPartExamined'),
+    Attribute('Manufacturer'),
+    Attribute('ProtocolName'),
     # Study-level pass-through
-    '0020000D': ModelField('StudyInstanceUID', vr='UI'),
-    '00100010': ModelField('PatientName', vr='PN', wildcard=True, fuzzy=True),
-    '00100020': ModelField('PatientID', vr='LO'),
-}
+    Attribute('StudyInstanceUID'),
+    Attribute('PatientName', fuzzy=True),
+    Attribute('PatientID'),
+]
 
-TAG_MAP_INSTANCE = {
-    '00080018': ModelField('SOPInstanceUID', vr='UI'),
-    '00080016': ModelField('SOPClassUID', vr='UI'),
-    '00200013': ModelField('InstanceNumber', vr='IS'),
-    '00280010': ModelField('Rows', vr='US'),
-    '00280011': ModelField('Columns', vr='US'),
-    '00280100': ModelField('BitsAllocated', vr='US'),
-    '00280008': ModelField('NumberOfFrames', vr='IS'),
+QUERY_FIELDS_INSTANCE = [
+    Attribute('SOPInstanceUID'),
+    Attribute('SOPClassUID'),
+    Attribute('InstanceNumber'),
+    Attribute('Rows'),
+    Attribute('Columns'),
+    Attribute('BitsAllocated'),
+    Attribute('NumberOfFrames'),
     # Series pass-through
-    '0020000E': ModelField('series__SeriesInstanceUID', vr='UI'),
-    '0020000D': ModelField('series__StudyInstanceUID', vr='UI'),
-}
+    Attribute('SeriesInstanceUID', orm_field='series__SeriesInstanceUID'),
+    Attribute('StudyInstanceUID', orm_field='series__StudyInstanceUID'),
+]
 
 
 # ---------------------------------------------------------------------------
 # QueryFilter
 # ---------------------------------------------------------------------------
-
-_RESERVED_PARAMS = frozenset({'limit', 'offset', 'includefield', 'fuzzymatching', 'orderby'})
-
 
 class QueryFilter:
     """
@@ -106,144 +234,79 @@ class QueryFilter:
     """
     HARD_LIMIT = 5000
     DEFAULT_LIMIT = 50
+    TAG_MAPS_BY_RESOURCE_TYPE = {
+        'study': {field.tag: field for field in QUERY_FIELDS_STUDY},
+        'series': {field.tag: field for field in QUERY_FIELDS_SERIES},
+        'instance': {field.tag: field for field in QUERY_FIELDS_INSTANCE},
+    }
 
-    def __init__(self, tag_map: dict):
-        self.tag_map = tag_map
-        self._kw_to_hex = {}
-        for hex_tag in tag_map:
-            if len(hex_tag) != 8:
-                continue
+    def __init__(self, target_resource_type: Literal['study', 'series', 'instance']):
+        self.tag_map = self.TAG_MAPS_BY_RESOURCE_TYPE[target_resource_type]
+
+    def apply(self, qs: QuerySet, search_query: SearchQuery) -> QuerySet:
+        """Filter a QuerySet according to a SearchQuery."""
+
+        for tag, values in search_query.match.items():
             try:
-                kw = pydicom.datadict.keyword_for_tag(int(hex_tag, 16))
-                if kw:
-                    self._kw_to_hex[kw] = hex_tag
-            except Exception:
-                pass
+                attribute = self.tag_map[tag]
+            except KeyError:
+                # Ignore any extra attributes
+                continue
 
-    def apply(self, qs: QuerySet, params) -> QuerySet:
-        """Apply DICOM match parameters from ``params`` to ``qs``."""
-        # Fuzzy Person-Name matching is a request-wide modifier, not a match key
-        # (PS3.18 §8.3.4.2). Resolve it once up front so it can influence PN terms.
-        fuzzy = (str(params.get('fuzzymatching', '')).lower() in ('true', '1', 'yes')
-                 if hasattr(params, 'get') else False)
+            q = Q()
+            for raw_value in values:
+                # Handle multiple and range values first
+                match attribute.parse(raw_value, search_query.multiplevaluematching):
+                    case RangeValue(start, end):
+                        range_q = Q(**{f'{attribute.orm_field}__gte': start})
+                        range_q &= Q(**{f'{attribute.orm_field}__lte': end})
+                        q |= range_q
+                        continue
+                    case MultipleValue(multi_values):
+                        q |= Q(**{f'{attribute.orm_field}__in': multi_values})
+                        continue
+                    case '' | None:
+                        # PS3.4 §C.2.2.2.3 Universal Matching
+                        continue
+                    case '""':
+                        # PS3.4 §C.2.2.2.7 Empty value matching
+                        if not search_query.emptyvaluematching:
+                            # TODO: log warning
+                            continue
+                        q |= Q(**{f'{attribute.orm_field}__exact': ''})
+                        continue
+                    case single_value:
+                        value = single_value
 
-        if isinstance(params, QueryDict):
-            items = params.items()
-        else:
-            items = params.items() if hasattr(params, 'items') else params
+                # Single value handling
+                if search_query.fuzzymatching and attribute.fuzzy:
+                    # Fuzzy matching
+                    q |= Q(**{f'{attribute.orm_field}__{attribute.fuzzy_lookup}': value})
+                elif attribute.cap_wildcard() and ('*' in value or '?' in value):
+                    # Wildcard matching
+                    q |= Q(**{f'{attribute.orm_field}__iregex': _wildcard_to_regex(value)})
+                else:
+                    q |= Q(**{attribute.orm_field: value})
 
-        for key, value in items:
-            if key in _RESERVED_PARAMS:
-                continue
-            if not value:
-                # §8.3.4.1 / PS3.4 §C.2.2.2: empty value → no restriction on that attribute
-                continue
-            hex_tag = self._resolve_tag(key)
-            if hex_tag is None:
-                continue
-            descriptor = self.tag_map.get(hex_tag)
-            if descriptor is None or isinstance(descriptor, Aggregation):
-                continue
-            qs = self._apply_field(qs, descriptor, value, fuzzy)
+            qs = qs.filter(q)
         return qs
 
-    def paginate(self, qs: QuerySet, params):
-        """Return (page_qs, total_count, effective_limit)."""
-        raw_limit = params.get('limit', self.DEFAULT_LIMIT) if hasattr(params, 'get') else self.DEFAULT_LIMIT
-        raw_offset = params.get('offset', 0) if hasattr(params, 'get') else 0
-        try:
-            limit = min(int(raw_limit), self.HARD_LIMIT)
-        except (TypeError, ValueError):
-            limit = self.DEFAULT_LIMIT
-        if limit < 0:
-            # A negative limit would produce a negative slice stop
-            # (qs[offset:offset+limit]), which Django rejects — treat as invalid.
-            limit = self.DEFAULT_LIMIT
-        try:
-            offset = max(int(raw_offset), 0)
-        except (TypeError, ValueError):
-            offset = 0
+    def paginate(self, qs: QuerySet, search_query: SearchQuery):
+        """Return a single page of a QuerySet using limit and offset specified in a SearchQuery.
+
+        Return Value: (page_qs, total_count, effective_limit).
+        """
+        limit = self.DEFAULT_LIMIT if search_query.limit is None else search_query.limit
+        offset = 0 if search_query.offset is None else search_query.offset
+
+        # Clip limit to [0..HARD_LIMIT]
+        limit = max(0, min(limit, self.HARD_LIMIT))
+
+        # Ensure a non-negative offset
+        offset = max(0, search_query.offset or 0)
+
         total = qs.count()
         return qs[offset:offset + limit], total, limit
-
-    # ── Private helpers ──────────────────────────────────────────────────────
-
-    def _resolve_tag(self, key: str) -> Optional[str]:
-        """Return the 8-hex-char tag for a *supported* attribute (hex or keyword
-        form), or None if the key is not a query attribute for this level.
-
-        Both forms are validated against ``tag_map`` so an unknown-but-well-formed
-        hex tag resolves to None (consistent with keyword lookup) — the caller then
-        drops it (PS3.18 §8.3.4.1: servers may ignore unsupported match keys).
-        """
-        upper = key.upper()
-        if len(upper) == 8 and all(c in '0123456789ABCDEF' for c in upper):
-            return upper if upper in self.tag_map else None
-        return self._kw_to_hex.get(key)  # case-sensitive keyword lookup
-
-    def _apply_field(self, qs: QuerySet, descriptor: ModelField, raw_value: str,
-                     fuzzy: bool = False) -> QuerySet:
-        field = descriptor.orm_path
-        vr = descriptor.vr
-        values = raw_value.split(',')  # multi-value → OR semantics
-
-        # Date/time range: only activate for DA/TM VRs with a single value containing '-'
-        if vr in ('DA', 'TM', 'DT') and descriptor.range_ and '-' in raw_value and len(values) == 1:
-            return self._apply_range(qs, field, vr, raw_value)
-
-        # Fuzzy Person-Name matching (PS3.18 §8.3.4.2). Applies only to fuzzy-eligible
-        # PN attributes when fuzzymatching=true and no wildcard is present — an explicit
-        # wildcard takes precedence and falls through to the wildcard path below.
-        if fuzzy and descriptor.fuzzy and '*' not in raw_value and '?' not in raw_value:
-            return self._apply_fuzzy(qs, field, values)
-
-        q = Q()
-        for v in values:
-            if descriptor.wildcard and ('*' in v or '?' in v):
-                like_val = v.replace('*', '%').replace('?', '_')
-                q |= Q(**{f'{field}__icontains': like_val.strip('%_')}) if like_val in ('%', '_') else Q(**{f'{field}__iregex': _like_to_regex(like_val)})
-            elif vr in ('DA', 'TM', 'DT'):
-                # Single-value DA/TM/DT: coerce the DICOM compact form
-                # (YYYYMMDD / HHMMSS) to a native date/time so the Date/TimeField
-                # comparison is unambiguous. Unparseable values add no restriction.
-                parsed = _parse_temporal(vr, v)
-                if parsed is not None:
-                    q |= Q(**{field: parsed})
-            elif vr == 'PN':
-                # PN: stored as 'FAMILY^GIVEN'; support exact or alphabetic-component prefix
-                q |= Q(**{f'{field}__iexact': v}) | Q(**{f'{field}__istartswith': v})
-            else:
-                q |= Q(**{f'{field}': v})
-        return qs.filter(q)
-
-    def _apply_fuzzy(self, qs: QuerySet, field: str, values) -> QuerySet:
-        """Fuzzy PN match via pg_trgm's ``%`` operator (Django ``__trigram_similar``).
-
-        GIN-index-backed. The match threshold is Postgres' session GUC
-        ``pg_trgm.similarity_threshold``, set per connection from
-        ``settings.DICOMWEB_FUZZY_THRESHOLD`` (see the DATABASES OPTIONS in the
-        environment settings). Multi-value → OR (PS3.18 §8.3.4.2, PS3.4 §C.2.2.2.1.1).
-        """
-        q = Q()
-        for v in values:
-            q |= Q(**{f'{field}__trigram_similar': v})
-        return qs.filter(q)
-
-    def _apply_range(self, qs: QuerySet, field: str, vr: str, raw_value: str) -> QuerySet:
-        parts = raw_value.split('-', 1)
-        start_str = parts[0].strip()
-        end_str = parts[1].strip() if len(parts) > 1 else ''
-        # Parse per the attribute's VR — a DA range yields dates, a TM range times,
-        # a DT range datetimes. (Previously this always used the DA parser, so TM/DT
-        # ranges silently parsed to None and applied no filter.)
-        start = _parse_temporal(vr, start_str) if start_str else None
-        end = _parse_temporal(vr, end_str) if end_str else None
-        if start is not None:
-            qs = qs.filter(**{f'{field}__gte': start})
-        if end is not None:
-            qs = qs.filter(**{f'{field}__lte': end})
-        return qs
-
 
 # ---------------------------------------------------------------------------
 # Internal utilities
@@ -274,7 +337,7 @@ def _parse_dt(s: str):
     """Parse a DICOM DT string (YYYYMMDD[HHMMSS], truncated forms allowed) to a
     Python datetime, or None on failure."""
     raw = s.split('.', 1)[0]
-    for fmt in ('%Y%m%d%H%M%S', '%Y%m%d%H%M', '%Y%m%d%H', '%Y%m%d'):
+    for fmt in ('%Y%m%d', '%Y%m%d%H', '%Y%m%d%H%M', '%Y%m%d%H%M%S'):
         try:
             return datetime.strptime(raw, fmt)
         except (ValueError, TypeError):
@@ -294,22 +357,18 @@ def _parse_temporal(vr: str, s: str):
     return None
 
 
-def _like_to_regex(like_val: str) -> str:
-    """Convert a SQL LIKE pattern (``%`` / ``_``) to an *anchored* POSIX regex.
-
-    Anchored at both ends (``^...$``) so wildcard matching keeps prefix/suffix
-    semantics — ``DOE*`` matches values *starting* with DOE, not merely containing
-    it — when used with Postgres' unanchored ``~*`` operator via ``__iregex``.
-    """
+def _wildcard_to_regex(value: str) -> str:
+    """Convert a wildcard pattern to POSIX regex."""
     import re
-    parts = re.split(r'([%_])', like_val)
-    result = ['^']
+    parts = re.split(r'([*?])', value)
+    result = []
     for part in parts:
-        if part == '%':
+        if part == '*':
             result.append('.*')
-        elif part == '_':
+        elif part == '?':
             result.append('.')
         else:
             result.append(re.escape(part))
-    result.append('$')
+    # wrap in ^$ to ensure a full match
+    result = ['^', *result, '$']
     return ''.join(result)

--- a/chris_backend/dicomweb/query.py
+++ b/chris_backend/dicomweb/query.py
@@ -155,6 +155,10 @@ class QueryFilter:
             limit = min(int(raw_limit), self.HARD_LIMIT)
         except (TypeError, ValueError):
             limit = self.DEFAULT_LIMIT
+        if limit < 0:
+            # A negative limit would produce a negative slice stop
+            # (qs[offset:offset+limit]), which Django rejects — treat as invalid.
+            limit = self.DEFAULT_LIMIT
         try:
             offset = max(int(raw_offset), 0)
         except (TypeError, ValueError):
@@ -165,10 +169,16 @@ class QueryFilter:
     # ── Private helpers ──────────────────────────────────────────────────────
 
     def _resolve_tag(self, key: str) -> Optional[str]:
-        """Return 8-hex-char tag from either hex form or DICOM keyword."""
+        """Return the 8-hex-char tag for a *supported* attribute (hex or keyword
+        form), or None if the key is not a query attribute for this level.
+
+        Both forms are validated against ``tag_map`` so an unknown-but-well-formed
+        hex tag resolves to None (consistent with keyword lookup) — the caller then
+        drops it (PS3.18 §8.3.4.1: servers may ignore unsupported match keys).
+        """
         upper = key.upper()
         if len(upper) == 8 and all(c in '0123456789ABCDEF' for c in upper):
-            return upper
+            return upper if upper in self.tag_map else None
         return self._kw_to_hex.get(key)  # case-sensitive keyword lookup
 
     def _apply_field(self, qs: QuerySet, descriptor: ModelField, raw_value: str,
@@ -192,6 +202,13 @@ class QueryFilter:
             if descriptor.wildcard and ('*' in v or '?' in v):
                 like_val = v.replace('*', '%').replace('?', '_')
                 q |= Q(**{f'{field}__icontains': like_val.strip('%_')}) if like_val in ('%', '_') else Q(**{f'{field}__iregex': _like_to_regex(like_val)})
+            elif vr in ('DA', 'TM', 'DT'):
+                # Single-value DA/TM/DT: coerce the DICOM compact form
+                # (YYYYMMDD / HHMMSS) to a native date/time so the Date/TimeField
+                # comparison is unambiguous. Unparseable values add no restriction.
+                parsed = _parse_temporal(vr, v)
+                if parsed is not None:
+                    q |= Q(**{field: parsed})
             elif vr == 'PN':
                 # PN: stored as 'FAMILY^GIVEN'; support exact or alphabetic-component prefix
                 q |= Q(**{f'{field}__iexact': v}) | Q(**{f'{field}__istartswith': v})
@@ -216,11 +233,14 @@ class QueryFilter:
         parts = raw_value.split('-', 1)
         start_str = parts[0].strip()
         end_str = parts[1].strip() if len(parts) > 1 else ''
-        start = _parse_da(start_str) if start_str else None
-        end = _parse_da(end_str) if end_str else None
-        if start:
+        # Parse per the attribute's VR — a DA range yields dates, a TM range times,
+        # a DT range datetimes. (Previously this always used the DA parser, so TM/DT
+        # ranges silently parsed to None and applied no filter.)
+        start = _parse_temporal(vr, start_str) if start_str else None
+        end = _parse_temporal(vr, end_str) if end_str else None
+        if start is not None:
             qs = qs.filter(**{f'{field}__gte': start})
-        if end:
+        if end is not None:
             qs = qs.filter(**{f'{field}__lte': end})
         return qs
 
@@ -237,11 +257,53 @@ def _parse_da(s: str):
         return None
 
 
+def _parse_tm(s: str):
+    """Parse a DICOM TM string (HHMMSS[.ffffff], truncated forms allowed) to a
+    Python time, or None on failure."""
+    raw = s.split('.', 1)[0]
+    fmt = {6: '%H%M%S', 4: '%H%M', 2: '%H'}.get(len(raw))
+    if fmt is None:
+        return None
+    try:
+        return datetime.strptime(raw, fmt).time()
+    except (ValueError, TypeError):
+        return None
+
+
+def _parse_dt(s: str):
+    """Parse a DICOM DT string (YYYYMMDD[HHMMSS], truncated forms allowed) to a
+    Python datetime, or None on failure."""
+    raw = s.split('.', 1)[0]
+    for fmt in ('%Y%m%d%H%M%S', '%Y%m%d%H%M', '%Y%m%d%H', '%Y%m%d'):
+        try:
+            return datetime.strptime(raw, fmt)
+        except (ValueError, TypeError):
+            continue
+    return None
+
+
+def _parse_temporal(vr: str, s: str):
+    """Parse a DICOM DA/TM/DT string into its native type (date/time/datetime),
+    or None. Dispatches on VR so range and exact matching coerce correctly."""
+    if vr == 'DA':
+        return _parse_da(s)
+    if vr == 'TM':
+        return _parse_tm(s)
+    if vr == 'DT':
+        return _parse_dt(s)
+    return None
+
+
 def _like_to_regex(like_val: str) -> str:
-    """Convert SQL LIKE pattern (with % and _) to a Python regex string."""
+    """Convert a SQL LIKE pattern (``%`` / ``_``) to an *anchored* POSIX regex.
+
+    Anchored at both ends (``^...$``) so wildcard matching keeps prefix/suffix
+    semantics — ``DOE*`` matches values *starting* with DOE, not merely containing
+    it — when used with Postgres' unanchored ``~*`` operator via ``__iregex``.
+    """
     import re
     parts = re.split(r'([%_])', like_val)
-    result = []
+    result = ['^']
     for part in parts:
         if part == '%':
             result.append('.*')
@@ -249,4 +311,5 @@ def _like_to_regex(like_val: str) -> str:
             result.append('.')
         else:
             result.append(re.escape(part))
+    result.append('$')
     return ''.join(result)

--- a/chris_backend/dicomweb/query.py
+++ b/chris_backend/dicomweb/query.py
@@ -276,7 +276,10 @@ class QueryFilter:
     }
 
     def __init__(self, target_resource_type: Literal['study', 'series', 'instance']):
-        self.tag_map = self.TAG_MAPS_BY_RESOURCE_TYPE[target_resource_type]
+        try:
+            self.tag_map = self.TAG_MAPS_BY_RESOURCE_TYPE[target_resource_type]
+        except KeyError:
+            raise ValueError(f'Unsupported resource type: "{target_resource_type}"')
 
     def apply(self, qs: QuerySet, search_query: SearchQuery) -> QuerySet:
         """Filter a QuerySet according to a SearchQuery."""

--- a/chris_backend/dicomweb/query.py
+++ b/chris_backend/dicomweb/query.py
@@ -8,22 +8,27 @@ Person-Name matching (§8.3.4.2), and limit/offset pagination (§8.3.4.4).
 
 Usage::
 
-    from dicomweb.query import QueryFilter, TAG_MAP_SERIES
+    from django.http import QueryDict
+    from dicomweb.query import QueryFilter, SearchQuery
 
-    qf = QueryFilter(TAG_MAP_SERIES)
-    qs = qf.apply(PACSSeries.objects.all(), request.query_params)
-    page, total, limit = qf.paginate(qs, request.query_params)
+    search_query = SearchQuery.from_query_dict(QueryDict('StudyInstanceUID=123'))
+    qf = QueryFilter('series')
+    qs = qf.apply(PACSSeries.objects.all(), search_query)
+    page, total, limit = qf.paginate(qs, search_query)
 """
 from dataclasses import dataclass
 from datetime import datetime
+import re
 from typing import Self, Optional, Literal, Any, Union
 
 import pydicom.datadict
-from django.db.models import Q, QuerySet
+import pydicom.tag
+from django.db.models import CharField, TextField, Q, QuerySet
 from django.http import QueryDict
 
 
 # Alias
+type TagType = pydicom.tag.TagType
 Tag = pydicom.tag.Tag
 
 # reserved words for search query parameters
@@ -35,9 +40,9 @@ _SEARCH_PARAMS = frozenset({
 
 @dataclass
 class SearchQuery:
-    match: dict[Tag, list[str]]
+    match: dict[TagType, list[str]]
     fuzzymatching: bool = False
-    includefield: Optional[Union[list[Tag], Literal['all']]] = None
+    includefield: Optional[Union[list[TagType], Literal['all']]] = None
     limit: Optional[int] = None
     offset: Optional[int] = None
     emptyvaluematching: bool = False
@@ -50,7 +55,7 @@ class SearchQuery:
     @classmethod
     def from_query_dict(cls, params: QueryDict) -> Self:
         # Split the query parameters into matches and search parameters
-        match_pairs = {}
+        match_pairs: dict[TagType, list[str]] = {}
         for param in params:
             if param not in _SEARCH_PARAMS:
                 try:
@@ -59,7 +64,7 @@ class SearchQuery:
                     continue
                 match_pairs[tag] = params.getlist(param)
 
-        search_options = {}
+        search_options: dict[str, Any] = {}
         if 'includefield' in params:
             # includefield can be passed multiple times and/or be a
             # comma-separated list. It may also include the special
@@ -87,10 +92,9 @@ class SearchQuery:
                 search_options[field] = cls._parse_bool(field_value)
 
         return cls(
-            match = match_pairs,
+            match=match_pairs,
             **search_options,
         )
-
 
 
 # Matching types for VRs
@@ -105,10 +109,28 @@ UID_LIST_VRS = frozenset({'UI'})
 # ---------------------------------------------------------------------------
 
 
+@dataclass(frozen=True, slots=True)
+class UniversalValue:
+    """Sentinel for universal matching."""
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class EmptyValue:
+    """Sentinel for empty value matching."""
+    pass
+
+
 @dataclass
 class RangeValue[T]:
-    start: T
-    end: T
+    start: Optional[T]
+    end: Optional[T]
+
+    def __post_init__(self):
+        # Validate open-ended ranges per PS3.4 §C.2.2.2.5.1
+        if self.start is None and self.end is None:
+            raise ValueError("Range must have at least one start or end value.")
+
 
 @dataclass
 class MultipleValue[T]:
@@ -119,11 +141,13 @@ class MultipleValue[T]:
 class Attribute:
     keyword: str
     orm_field: str = ""         # Will default to keyword if unset
-    fuzzy: bool = False # eligible for fuzzy PN matching (PS3.18 §8.3.4.2)
-    fuzzy_lookup: str = "trigram_similar"
-    tag: Optional[Tag] = None
+    tag: Optional[TagType] = None
     vr: Optional[str] = None
     vm: Optional[str] = None
+    standard_lookup: str = 'exact'
+    wildcard_lookup: str = 'regex'
+    fuzzy: bool = False  # eligible for fuzzy PN matching (PS3.18 §8.3.4.2)
+    fuzzy_lookup: str = "trigram_similar"
 
     def __post_init__(self):
         if self.orm_field == "":
@@ -134,6 +158,9 @@ class Attribute:
             self.vr = pydicom.datadict.dictionary_VR(self.tag)
         if self.vm is None:
             self.vm = pydicom.datadict.dictionary_VM(self.tag)
+        if self.vr == 'PN':
+            self.standard_lookup = 'iexact'
+            self.wildcard_lookup = 'iregex'
 
     def cap_wildcard(self) -> bool:
         return self.vr in WILDCARD_VRS
@@ -147,12 +174,17 @@ class Attribute:
             return False
         return self.vm != '1'
 
-    def parse(self, value: str, multi_value: bool=False) -> Any:
+    def parse(self, value: str, multi_value: bool = False) -> Any:
+        if value == '':
+            return UniversalValue()
+        if value == '""':
+            return EmptyValue()
         if self.cap_range() and "-" in value:
             return self.parse_range(value)
-        if self.cap_multi_value() and multi_value:
+        if self.vr in UID_LIST_VRS or (self.cap_multi_value() and multi_value):
             parsed_value = self.parse_multiple(value)
-            if len(parsed_value.values) == 1:
+            length = len(parsed_value.values)
+            if length == 1:
                 return parsed_value.values[0]
             return parsed_value
         return self.parse_single(value)
@@ -167,11 +199,14 @@ class Attribute:
         if '-' not in value:
             raise ValueError(f'Invalid range value: {value}')
         start, end = value.split('-', maxsplit=1)
-        return RangeValue(self.parse_single(start), self.parse_single(end))
+        result = RangeValue(
+            self.parse_single(start) if start != '' else None,
+            self.parse_single(end) if end != '' else None,
+        )
+        return result
 
     def parse_multiple(self, value: str) -> MultipleValue:
-        import re
-        return MultipleValue([self.parse_single(v) for v in re.split(r'[\\,]', value)])
+        return MultipleValue([self.parse_single(v) for v in re.split(r'[\\,]', value) if len(v) > 0])
 
 
 # ---------------------------------------------------------------------------
@@ -258,41 +293,48 @@ class QueryFilter:
                 # Handle multiple and range values first
                 match attribute.parse(raw_value, search_query.multiplevaluematching):
                     case RangeValue(start, end):
-                        range_q = Q(**{f'{attribute.orm_field}__gte': start})
-                        range_q &= Q(**{f'{attribute.orm_field}__lte': end})
+                        range_q = Q()
+                        if start is not None:
+                            range_q &= Q(**{f'{attribute.orm_field}__gte': start})
+                        if end is not None:
+                            range_q &= Q(**{f'{attribute.orm_field}__lte': end})
                         q |= range_q
                         continue
                     case MultipleValue(multi_values):
                         q |= Q(**{f'{attribute.orm_field}__in': multi_values})
                         continue
-                    case '' | None:
+                    case UniversalValue():
                         # PS3.4 §C.2.2.2.3 Universal Matching
                         continue
-                    case '""':
+                    case EmptyValue():
                         # PS3.4 §C.2.2.2.7 Empty value matching
                         if not search_query.emptyvaluematching:
                             # TODO: log warning
                             continue
-                        q |= Q(**{f'{attribute.orm_field}__exact': ''})
+                        # Match NULL or '' on text columns
+                        q |= Q(**{f'{attribute.orm_field}__isnull': True})
+                        if _is_text_column(qs.model, attribute.orm_field):
+                            q |= Q(**{attribute.orm_field: ''})
                         continue
                     case single_value:
                         value = single_value
 
                 # Single value handling
-                if search_query.fuzzymatching and attribute.fuzzy:
-                    # Fuzzy matching
-                    q |= Q(**{f'{attribute.orm_field}__{attribute.fuzzy_lookup}': value})
-                elif attribute.cap_wildcard() and ('*' in value or '?' in value):
+                if attribute.cap_wildcard() and ('*' in value or '?' in value):
                     # Wildcard matching
-                    q |= Q(**{f'{attribute.orm_field}__iregex': _wildcard_to_regex(value)})
+                    q |= Q(**{f'{attribute.orm_field}__{attribute.wildcard_lookup}': _wildcard_to_regex(value)})
                 else:
-                    q |= Q(**{attribute.orm_field: value})
+                    if search_query.fuzzymatching and attribute.fuzzy:
+                        # Fuzzy matching
+                        q |= Q(**{f'{attribute.orm_field}__{attribute.fuzzy_lookup}': value})
+                    q |= Q(**{f'{attribute.orm_field}__{attribute.standard_lookup}': value})
 
             qs = qs.filter(q)
         return qs
 
     def paginate(self, qs: QuerySet, search_query: SearchQuery):
-        """Return a single page of a QuerySet using limit and offset specified in a SearchQuery.
+        """Return a single page of a QuerySet using limit and offset
+        specified in a SearchQuery.
 
         Return Value: (page_qs, total_count, effective_limit).
         """
@@ -303,21 +345,33 @@ class QueryFilter:
         limit = max(0, min(limit, self.HARD_LIMIT))
 
         # Ensure a non-negative offset
-        offset = max(0, search_query.offset or 0)
+        offset = max(0, offset)
 
         total = qs.count()
         return qs[offset:offset + limit], total, limit
 
+
 # ---------------------------------------------------------------------------
 # Internal utilities
 # ---------------------------------------------------------------------------
+
+
+def _is_text_column(model, orm_field: str) -> bool:
+    """Determine whether ``orm_field`` maps to a text column."""
+    field = None
+    for part in orm_field.split('__'):
+        field = model._meta.get_field(part)
+        if field.is_relation:
+            model = field.related_model
+    return isinstance(field, (CharField, TextField))
+
 
 def _parse_da(s: str):
     """Parse DICOM DA string (YYYYMMDD) to Python date, or None on failure."""
     try:
         return datetime.strptime(s[:8], '%Y%m%d').date()
     except (ValueError, TypeError):
-        return None
+        raise ValueError(f'Unable to parse date value: {s}')
 
 
 def _parse_tm(s: str):
@@ -326,11 +380,11 @@ def _parse_tm(s: str):
     raw = s.split('.', 1)[0]
     fmt = {6: '%H%M%S', 4: '%H%M', 2: '%H'}.get(len(raw))
     if fmt is None:
-        return None
+        raise ValueError(f'Unable to parse time value: {s}')
     try:
         return datetime.strptime(raw, fmt).time()
     except (ValueError, TypeError):
-        return None
+        raise ValueError(f'Unable to parse time value: {s}')
 
 
 def _parse_dt(s: str):
@@ -342,7 +396,7 @@ def _parse_dt(s: str):
             return datetime.strptime(raw, fmt)
         except (ValueError, TypeError):
             continue
-    return None
+    raise ValueError(f'Unable to parse datetime value: {s}')
 
 
 def _parse_temporal(vr: str, s: str):
@@ -354,12 +408,11 @@ def _parse_temporal(vr: str, s: str):
         return _parse_tm(s)
     if vr == 'DT':
         return _parse_dt(s)
-    return None
+    raise TypeError(f'Invalid VR for temporal value: {vr}')
 
 
 def _wildcard_to_regex(value: str) -> str:
     """Convert a wildcard pattern to POSIX regex."""
-    import re
     parts = re.split(r'([*?])', value)
     result = []
     for part in parts:

--- a/chris_backend/dicomweb/tests/test_query.py
+++ b/chris_backend/dicomweb/tests/test_query.py
@@ -1,342 +1,585 @@
 """
-Unit tests for dicomweb.query — QIDO-RS DICOM-tag query parser.
+Unit tests for ``dicomweb.query`` — the QIDO-RS DICOM-tag query parser
+(PS3.18 §10.6 Search Transaction; matching semantics per PS3.4 §C.2.2.2).
 """
+from datetime import date, time, datetime
+
 from django.http import QueryDict
-from django.test import TestCase
+from django.test import TestCase, SimpleTestCase
 
-from dicomweb.query import QueryFilter, SERIES_FIELDS_BY_TAG, TAG_MAP_STUDY, _parse_da
+from dicomweb.query import (
+    SearchQuery, QueryFilter, Attribute, RangeValue, Tag,
+    _parse_da, _parse_tm, _parse_dt, _parse_temporal, _wildcard_to_regex,
+)
 
 
-class ParseDaTest(TestCase):
+# ===========================================================================
+# SearchQuery
+# ===========================================================================
+class ParseBoolTest(SimpleTestCase):
 
-    def test_valid_date(self):
-        from datetime import date
+    def test_truthy_values(self):
+        for v in ('true', '1', 'yes', 'TRUE', 'Yes', 'YES'):
+            with self.subTest(v=v):
+                self.assertTrue(SearchQuery._parse_bool(v))
+
+    def test_falsy_values(self):
+        for v in ('false', '0', 'no', '', 'nope'):
+            with self.subTest(v=v):
+                self.assertFalse(SearchQuery._parse_bool(v))
+
+
+class FromQueryDictTest(SimpleTestCase):
+
+    def test_keyword_and_hex_resolve_to_same_tag(self):
+        kw = SearchQuery.from_query_dict(QueryDict('PatientName=DOE'))
+        hexq = SearchQuery.from_query_dict(QueryDict('00100010=DOE'))
+        self.assertIn(Tag('PatientName'), kw.match)
+        self.assertIn(Tag('PatientName'), hexq.match)
+        self.assertEqual(kw.match[Tag('PatientName')], ['DOE'])
+
+    def test_repeated_param_collected_as_list(self):
+        sq = SearchQuery.from_query_dict(QueryDict('Modality=CT&Modality=MR'))
+        self.assertEqual(sq.match[Tag('Modality')], ['CT', 'MR'])
+
+    def test_reserved_params_excluded_from_match(self):
+        sq = SearchQuery.from_query_dict(
+            QueryDict('PatientName=DOE&limit=5&offset=2&fuzzymatching=true'))
+        self.assertEqual(list(sq.match), [Tag('PatientName')])
+
+    def test_includefield_all(self):
+        sq = SearchQuery.from_query_dict(QueryDict('includefield=all'))
+        self.assertEqual(sq.includefield, 'all')
+
+    def test_includefield_list_repeated_form(self):
+        # Repeated-parameter form collects each resolved tag, in order.
+        sq = SearchQuery.from_query_dict(
+            QueryDict('includefield=Modality&includefield=00080061'))
+        self.assertEqual(sq.includefield,
+                         [Tag('Modality'), Tag('00080061')])
+
+    def test_includefield_absent_is_none(self):
+        self.assertIsNone(SearchQuery.from_query_dict(QueryDict('')).includefield)
+
+    def test_limit_and_offset_parsed_as_int(self):
+        sq = SearchQuery.from_query_dict(QueryDict('limit=25&offset=10'))
+        self.assertEqual((sq.limit, sq.offset), (25, 10))
+
+    def test_limit_offset_absent_are_none(self):
+        sq = SearchQuery.from_query_dict(QueryDict(''))
+        self.assertEqual((sq.limit, sq.offset), (None, None))
+
+    def test_bool_flags_parsed(self):
+        sq = SearchQuery.from_query_dict(QueryDict(
+            'fuzzymatching=true&emptyvaluematching=1&multiplevaluematching=yes'))
+        self.assertTrue(sq.fuzzymatching)
+        self.assertTrue(sq.emptyvaluematching)
+        self.assertTrue(sq.multiplevaluematching)
+
+    def test_bool_flags_default_false(self):
+        sq = SearchQuery.from_query_dict(QueryDict(''))
+        self.assertFalse(sq.fuzzymatching)
+        self.assertFalse(sq.emptyvaluematching)
+        self.assertFalse(sq.multiplevaluematching)
+
+    def test_unknown_hex_tag_is_kept_verbatim(self):
+        # A syntactically-valid but unsupported tag survives parsing (it is
+        # dropped later, in QueryFilter.apply).
+        sq = SearchQuery.from_query_dict(QueryDict('99990001=x'))
+        self.assertIn(Tag('99990001'), sq.match)
+
+    def test_unknown_keyword_dropped(self):
+        # An unresolvable keyword is caught (ValueError/OverflowError) and
+        # silently dropped from the match set.
+        sq = SearchQuery.from_query_dict(QueryDict('NotARealTag=x'))
+        self.assertEqual(list(sq.match), [])
+
+    def test_comma_joined_includefield(self):
+        sq = SearchQuery.from_query_dict(QueryDict('includefield=00080060,Modality'))
+        self.assertEqual(sq.includefield, [Tag('00080060'), Tag('Modality')])
+
+    def test_include_unknown_field(self):
+        # Unkown fields are silently dropped in both csv and
+        # single-value forms
+        sq = SearchQuery.from_query_dict(QueryDict('includefield=XxNoSuchFieldxX,Modality'))
+        self.assertEqual(sq.includefield, [Tag('Modality')])
+        sq = SearchQuery.from_query_dict(QueryDict('includefield=XxNoSuchFieldxX'))
+        self.assertEqual(sq.includefield, [])
+
+    def test_non_integer_limit_raises(self):
+        with self.assertRaises(ValueError):
+            SearchQuery.from_query_dict(QueryDict('limit=notanumber'))
+
+    def test_non_integer_offset_raises(self):
+        with self.assertRaises(ValueError):
+            SearchQuery.from_query_dict(QueryDict('offset=notanumber'))
+
+
+# ===========================================================================
+# Attribute descriptor
+# ===========================================================================
+class AttributeTest(SimpleTestCase):
+
+    def test_orm_field_defaults_to_keyword(self):
+        self.assertEqual(Attribute('PatientName').orm_field, 'PatientName')
+
+    def test_orm_field_explicit_is_preserved(self):
+        a = Attribute('SeriesInstanceUID', orm_field='series__SeriesInstanceUID')
+        self.assertEqual(a.orm_field, 'series__SeriesInstanceUID')
+
+    def test_tag_and_vr_resolved(self):
+        a = Attribute('PatientName')
+        self.assertEqual(a.tag, Tag(0x00100010))
+        self.assertEqual(a.vr, 'PN')
+
+    def test_cap_wildcard(self):
+        self.assertTrue(Attribute('Wildcard', tag='wc', vr='PN', vm='1').cap_wildcard())
+        self.assertFalse(Attribute('NoWildcard', tag='wc', vr='UI', vm='1').cap_wildcard())
+        self.assertTrue(Attribute('PatientName').cap_wildcard())   # PN
+        self.assertTrue(Attribute('Modality').cap_wildcard())      # CS
+        self.assertFalse(Attribute('StudyInstanceUID').cap_wildcard())  # UI
+
+    def test_cap_range(self):
+        self.assertTrue(Attribute('StudyDate').cap_range())        # DA
+        self.assertTrue(Attribute('StudyTime').cap_range())        # TM
+        self.assertFalse(Attribute('PatientName').cap_range())     # PN
+
+    def test_cap_multi_value_honors_vr_and_vm(self):
+        # Multi-capable only when the VR is a multi-value VR AND VM != 1.
+        self.assertTrue(
+            Attribute('MultiVr', tag='multi', vr='AE', vm='1-n').cap_multi_value())
+        self.assertFalse(
+            Attribute('SingleVm', tag='single', vr='AE', vm='1').cap_multi_value())   # VM=1
+        self.assertFalse(
+            Attribute('NonMultiVr', tag='nm', vr='UI', vm='1-n').cap_multi_value())    # VR not multi
+
+    # -- parse dispatch ----------------------------------------------------- #
+    def test_parse_single_non_temporal_returns_raw(self):
+        self.assertEqual(Attribute('PatientName').parse_single('DOE'), 'DOE')
+
+    def test_parse_single_temporal_coerces(self):
+        self.assertEqual(Attribute('StudyDate').parse_single('20230101'),
+                         date(2023, 1, 1))
+        self.assertEqual(Attribute('StudyTime').parse_single('120000'),
+                         time(12, 0, 0))
+
+    def test_parse_range_returns_rangevalue(self):
+        rv = Attribute('StudyDate').parse_range('20230101-20231231')
+        self.assertEqual(rv, RangeValue(date(2023, 1, 1), date(2023, 12, 31)))
+
+    def test_parse_range_without_dash_raises(self):
+        with self.assertRaises(ValueError):
+            Attribute('StudyDate').parse_range('20230101')
+
+    def test_parse_multiple_splits_on_comma_and_backslash(self):
+        self.assertEqual(Attribute('Modality').parse_multiple('CT,MR').values,
+                         ['CT', 'MR'])
+        self.assertEqual(Attribute('Modality').parse_multiple('CT\\MR').values,
+                         ['CT', 'MR'])
+
+    def test_parse_dispatch_range(self):
+        self.assertEqual(Attribute('StudyDate').parse('20230101-20231231'),
+                         RangeValue(date(2023, 1, 1), date(2023, 12, 31)))
+
+    def test_parse_dispatch_multiple_multi(self):
+        # ModalitiesInStudy (CS, VM 1-n) is genuinely multi-valued; Modality is
+        # VM=1 and would not take the multi path.
+        result = Attribute('ModalitiesInStudy').parse('CT,MR', multi_value=True)
+        self.assertEqual(result.values, ['CT', 'MR'])
+
+    def test_parse_dispatch_multiple_single_element_unwrapped(self):
+        # A single value with multiplevaluematching returns the scalar, not a
+        # MultipleValue wrapper (needs a VM>1 attribute so the multi path runs).
+        self.assertEqual(
+            Attribute('ModalitiesInStudy').parse('CT', multi_value=True), 'CT')
+
+    def test_parse_dispatch_single(self):
+        self.assertEqual(Attribute('PatientName').parse('DOE'), 'DOE')
+
+
+# ===========================================================================
+# QueryFilter — construction
+# ===========================================================================
+class QueryFilterInitTest(SimpleTestCase):
+
+    def test_map_keyed_by_tag(self):
+        self.assertIn(Tag('SeriesNumber'), QueryFilter('series').tag_map)
+
+    def test_unknown_resource_type_raises(self):
+        with self.assertRaises(KeyError):
+            QueryFilter('bogus')
+
+
+# ===========================================================================
+# QueryFilter.apply — compiled-SQL shape (no rows needed)
+# ===========================================================================
+class ApplySqlShapeTest(TestCase):
+
+    def _sql(self, resource, querystring):
+        from pacsfiles.models import PACSSeries
+        qf = QueryFilter(resource)
+        sq = SearchQuery.from_query_dict(QueryDict(querystring))
+        qs = qf.apply(PACSSeries.objects.all(), sq)
+        return qs.query.sql_with_params()[0]
+
+    def _has_where(self, resource, querystring):
+        from pacsfiles.models import PACSSeries
+        qf = QueryFilter(resource)
+        sq = SearchQuery.from_query_dict(QueryDict(querystring))
+        qs = qf.apply(PACSSeries.objects.all(), sq)
+        return 'WHERE' in str(qs.query)
+
+    def test_exact_match_uses_equality(self):
+        sql = self._sql('series', 'PatientName=DOE')
+        self.assertIn('"PatientName" = ', sql)
+
+    def test_unsupported_tag_produces_no_filter(self):
+        # Valid-but-unsupported tag (9999,0001) is silently dropped.
+        self.assertFalse(self._has_where('series', '99990001=x'))
+
+    def test_fuzzy_pn_uses_trigram_operator(self):
+        # pg_trgm '%' operator renders as escaped '%%' in compiled SQL.
+        self.assertIn('%%', self._sql('series', 'PatientName=DOE&fuzzymatching=true'))
+
+    def test_fuzzy_not_applied_without_flag(self):
+        self.assertNotIn('%%', self._sql('series', 'PatientName=DOE'))
+
+    def test_fuzzy_gated_on_fuzzy_eligible_attribute(self):
+        # Modality (fuzzy=False) must not use the trigram operator even with the flag.
+        self.assertNotIn('%%', self._sql('series', 'Modality=CT&fuzzymatching=true'))
+
+    def test_fuzzy_precedence_over_wildcard(self):
+        # Documented: with fuzzymatching on, a PN value is sent through the fuzzy
+        # branch even when it contains a wildcard char (fuzzy is checked first).
+        self.assertIn('%%', self._sql('series', 'PatientName=DOE*&fuzzymatching=true'))
+
+    def test_range_emits_gte_and_lte(self):
+        sql = self._sql('study', 'StudyDate=20230101-20231231')
+        self.assertIn('>=', sql)
+        self.assertIn('<=', sql)
+
+    def test_multiple_value_emits_in(self):
+        # No supported field has VM>1, so the multi-value IN path is unreachable
+        # through the resource maps. Drive it with a genuinely multi-valued
+        # attribute (ModalitiesInStudy, CS VM 1-n) mapped onto a real column.
+        from pacsfiles.models import PACSSeries
+        attr = Attribute('ModalitiesInStudy', orm_field='Modality')
+        qf = QueryFilter('series')
+        qf.tag_map = {attr.tag: attr}
+        sq = SearchQuery.from_query_dict(
+            QueryDict('ModalitiesInStudy=CT,MR&multiplevaluematching=true'))
+        sql = qf.apply(PACSSeries.objects.all(), sq).query.sql_with_params()[0]
+        self.assertIn('IN (', sql)
+
+    def test_quoted_empty_skipped_without_flag(self):
+        self.assertFalse(self._has_where('series', 'PatientName=""'))
+
+    def test_quoted_empty_matched_with_flag(self):
+        sql = self._sql('series', 'PatientName=""&emptyvaluematching=true')
+        self.assertIn('"PatientName" = ', sql)
+
+    def test_distinct_attributes_are_anded(self):
+        sql = self._sql('series', 'PatientName=DOE&Modality=CT')
+        self.assertIn(' AND ', sql)
+
+    def test_instance_resource_passthrough_orm_field(self):
+        # The instance map routes SeriesInstanceUID through the series__ FK path,
+        # so it filters via a JOIN to the series table.
+        from dicomweb.models import PACSInstance
+        qf = QueryFilter('instance')
+        sq = SearchQuery.from_query_dict(QueryDict('SeriesInstanceUID=1.2.3'))
+        sql = qf.apply(PACSInstance.objects.all(), sq).query.sql_with_params()[0]
+        self.assertIn('pacsfiles_pacsseries', sql)          # joined series table
+        self.assertIn('"SeriesInstanceUID" = ', sql)
+
+    def test_temporal_empty_is_universal_matching(self):
+        # PS3.4 §C.2.2.2.3: a zero-length value is universal matching (no
+        # restriction) — including temporal VRs, whose empty value parses to
+        # None and must not emit `StudyDate IS NULL`.
+        self.assertFalse(self._has_where('study', 'StudyDate='))
+
+
+# ===========================================================================
+# QueryFilter.apply — behavior against real rows
+# ===========================================================================
+class ApplyBehaviorTest(TestCase):
+
+    def setUp(self):
+        from django.contrib.auth.models import User
+        from core.models import ChrisFolder
+        from pacsfiles.models import PACS
+        self.user = User.objects.get(username='chris')
+        folder, _ = ChrisFolder.objects.get_or_create(
+            path='SERVICES/PACS/QTEST', owner=self.user)
+        self.pacs, _ = PACS.objects.get_or_create(folder=folder, identifier='QTEST')
+        self._n = 0
+        self.qf = QueryFilter('series')
+
+    def _series(self, **overrides):
+        from core.models import ChrisFolder
+        from pacsfiles.models import PACSSeries
+        self._n += 1
+        uid = f'1.2.{self._n}'
+        folder, _ = ChrisFolder.objects.get_or_create(
+            path=f'SERVICES/PACS/QTEST/{uid}', owner=self.user)
+        fields = dict(PatientID='P', PatientName='X^Y', StudyDate=date(2023, 1, 1),
+                      StudyInstanceUID='1.2', SeriesInstanceUID=uid,
+                      folder=folder, pacs=self.pacs)
+        fields.update(overrides)
+        return PACSSeries.objects.create(**fields)
+
+    def _names(self, querystring, resource='series'):
+        from pacsfiles.models import PACSSeries
+        qf = QueryFilter(resource)
+        sq = SearchQuery.from_query_dict(QueryDict(querystring))
+        return set(qf.apply(PACSSeries.objects.all(), sq)
+                   .values_list('PatientName', flat=True))
+
+    def test_exact_match(self):
+        self._series(PatientName='DOE^JANE')
+        self._series(PatientName='SMITH^JOHN')
+        self.assertEqual(self._names('PatientName=DOE^JANE'), {'DOE^JANE'})
+
+    def test_multiple_value_matching(self):
+        # No supported field has VM>1, so the multi-value path is exercised via a
+        # genuinely multi-valued attribute (ModalitiesInStudy, CS VM 1-n) mapped
+        # onto the real Modality column.
+        from pacsfiles.models import PACSSeries
+        self._series(PatientName='A', Modality='CT')
+        self._series(PatientName='B', Modality='MR')
+        self._series(PatientName='C', Modality='US')
+        attr = Attribute('ModalitiesInStudy', orm_field='Modality')
+        qf = QueryFilter('series')
+        qf.tag_map = {attr.tag: attr}
+        sq = SearchQuery.from_query_dict(
+            QueryDict('ModalitiesInStudy=CT,MR&multiplevaluematching=true'))
+        names = set(qf.apply(PACSSeries.objects.all(), sq)
+                    .values_list('PatientName', flat=True))
+        self.assertEqual(names, {'A', 'B'})
+
+    def test_date_range_matching(self):
+        self._series(PatientName='IN', StudyDate=date(2023, 6, 1))
+        self._series(PatientName='OUT', StudyDate=date(2024, 1, 1))
+        self.assertEqual(self._names('StudyDate=20230101-20231231', 'study'), {'IN'})
+
+    def test_single_value_exact_date(self):
+        self._series(PatientName='HIT', StudyDate=date(2023, 1, 1))
+        self._series(PatientName='MISS', StudyDate=date(2024, 6, 15))
+        self.assertEqual(self._names('StudyDate=20230101', 'study'), {'HIT'})
+
+    def test_time_range_matching(self):
+        self._series(PatientName='LOW', StudyTime=time(11, 0))
+        self._series(PatientName='MID', StudyTime=time(12, 30))
+        self._series(PatientName='HIGH', StudyTime=time(14, 0))
+        self.assertEqual(self._names('StudyTime=120000-130000', 'study'), {'MID'})
+
+    def test_fuzzy_matches_near_miss_and_excludes_dissimilar(self):
+        # 'JOE^JANE' is a one-char transposition of stored 'DOE^JANE': literal
+        # matching misses it, trigram similarity catches it.
+        self._series(PatientName='DOE^JANE')
+        self._series(PatientName='SMITH^JOHN')
+        names = self._names('PatientName=JOE^JANE&fuzzymatching=true')
+        self.assertIn('DOE^JANE', names)
+        self.assertNotIn('SMITH^JOHN', names)
+
+    def test_non_fuzzy_literal_misses_near_miss(self):
+        self._series(PatientName='DOE^JANE')
+        self.assertEqual(self._names('PatientName=JOE^JANE'), set())
+
+    def test_wildcard_prefix_matching(self):
+        self._series(PatientName='DOE^JANE')
+        self._series(PatientName='MCDOE^JOHN')
+        names = self._names('PatientName=DOE*')
+        self.assertIn('DOE^JANE', names)
+        self.assertNotIn('MCDOE^JOHN', names)
+
+    def test_bare_equals_universal_matching(self):
+        from pacsfiles.models import PACSSeries
+        self._series(PatientName='DOE^JANE')
+        self._series(PatientName='JOHN^SMITH')
+        all_names = sorted(
+            PACSSeries.objects.all()
+            .values_list('PatientName', flat=True)
+        )
+        returned_names = sorted(self._names('PatientName='))
+        self.assertEqual(returned_names, all_names)
+
+    def test_empty_value_matching(self):
+        self._series(Modality='', PatientName='EMPTY')
+        self._series(Modality='CT', PatientName='NOT^EMPTY')
+        self.assertEqual(self._names('Modality=""&emptyvaluematching=true&PatientName=NOT^EMPTY'), set())
+        self.assertEqual(self._names('Modality=""&emptyvaluematching=false&PatientName=NOT^EMPTY'), {'NOT^EMPTY'})
+        self.assertEqual(self._names('Modality=""&emptyvaluematching=true'), {'EMPTY'})
+        self.assertEqual(self._names('Modality=""&emptyvaluematching=false'), {'NOT^EMPTY', 'EMPTY'})
+        self.assertEqual(self._names('Modality=""'), {'NOT^EMPTY', 'EMPTY'})
+
+
+# ===========================================================================
+# QueryFilter.paginate
+# ===========================================================================
+class PaginateTest(TestCase):
+
+    def setUp(self):
+        self.qf = QueryFilter('series')
+
+    def _paginate(self, querystring):
+        from pacsfiles.models import PACSSeries
+        sq = SearchQuery.from_query_dict(QueryDict(querystring))
+        return self.qf.paginate(PACSSeries.objects.none(), sq)
+
+    def test_default_limit(self):
+        _, _, limit = self._paginate('')
+        self.assertEqual(limit, self.qf.DEFAULT_LIMIT)
+
+    def test_limit_clipped_to_hard_limit(self):
+        _, _, limit = self._paginate('limit=9999')
+        self.assertEqual(limit, self.qf.HARD_LIMIT)
+
+    def test_explicit_limit_within_bounds(self):
+        _, _, limit = self._paginate('limit=10')
+        self.assertEqual(limit, 10)
+
+    def test_negative_limit_clipped_to_zero(self):
+        page, _, limit = self._paginate('limit=-5')
+        self.assertEqual(limit, 0)
+        self.assertEqual(list(page), [])  # negative slice must not raise
+
+    def test_zero_limit(self):
+        _, _, limit = self._paginate('limit=0')
+        self.assertEqual(limit, 0)
+
+    def test_negative_offset_clipped_to_zero(self):
+        # Offset is floored at 0; the query must still build and slice cleanly.
+        page, _, _ = self._paginate('offset=-3&limit=5')
+        self.assertEqual(list(page), [])
+
+    def test_total_count_returned(self):
+        from pacsfiles.models import PACSSeries
+        sq = SearchQuery.from_query_dict(QueryDict('limit=5'))
+        _, total, _ = self.qf.paginate(PACSSeries.objects.all(), sq)
+        self.assertEqual(total, 0)
+
+    def _make_series(self, n):
+        from django.contrib.auth.models import User
+        from core.models import ChrisFolder
+        from pacsfiles.models import PACS, PACSSeries
+        user = User.objects.get(username='chris')
+        pfolder, _ = ChrisFolder.objects.get_or_create(
+            path='SERVICES/PACS/PGT', owner=user)
+        pacs, _ = PACS.objects.get_or_create(folder=pfolder, identifier='PGT')
+        for i in range(n):
+            f, _ = ChrisFolder.objects.get_or_create(
+                path=f'SERVICES/PACS/PGT/1.{i}', owner=user)
+            PACSSeries.objects.create(
+                PatientID='P', PatientName=f'N{i}', StudyDate=date(2023, 1, 1),
+                StudyInstanceUID='1', SeriesInstanceUID=f'1.{i}',
+                folder=f, pacs=pacs)
+
+    def test_offset_and_limit_slice(self):
+        from pacsfiles.models import PACSSeries
+        self._make_series(5)
+        sq = SearchQuery.from_query_dict(QueryDict('limit=2&offset=1'))
+        page, total, limit = self.qf.paginate(
+            PACSSeries.objects.all().order_by('SeriesInstanceUID'), sq)
+        self.assertEqual(total, 5)
+        self.assertEqual(limit, 2)
+        self.assertEqual([item.SeriesInstanceUID for item in page], ['1.1', '1.2'])
+
+
+
+# ===========================================================================
+# Temporal parsing helpers
+# ===========================================================================
+class ParseDaTest(SimpleTestCase):
+
+    def test_valid(self):
         self.assertEqual(_parse_da('20230102'), date(2023, 1, 2))
 
-    def test_invalid_date_returns_none(self):
+    def test_truncates_trailing(self):
+        self.assertEqual(_parse_da('20230102120000'), date(2023, 1, 2))
+
+    def test_invalid_returns_none(self):
         self.assertIsNone(_parse_da('not-a-date'))
 
     def test_empty_returns_none(self):
         self.assertIsNone(_parse_da(''))
 
 
-class QueryFilterTagResolutionTest(TestCase):
+class ParseTmTest(SimpleTestCase):
 
-    def setUp(self):
-        self.qf = QueryFilter(SERIES_FIELDS_BY_TAG)
+    def test_full_hhmmss(self):
+        self.assertEqual(_parse_tm('120000'), time(12, 0, 0))
 
-    def test_hex_tag_lookup(self):
-        self.assertEqual(self.qf._resolve_tag('00100010'), '00100010')
+    def test_hhmm(self):
+        self.assertEqual(_parse_tm('1230'), time(12, 30))
 
-    def test_keyword_lookup(self):
-        # PatientName keyword → same hex as 00100010
-        self.assertEqual(self.qf._resolve_tag('PatientName'), '00100010')
+    def test_hh(self):
+        self.assertEqual(_parse_tm('12'), time(12))
 
-    def test_lowercase_hex_normalised(self):
-        self.assertEqual(self.qf._resolve_tag('00100010'), '00100010')
+    def test_fractional_seconds_stripped(self):
+        self.assertEqual(_parse_tm('120000.500000'), time(12, 0, 0))
 
-    def test_unknown_returns_none(self):
-        self.assertIsNone(self.qf._resolve_tag('99990001'))
+    def test_unsupported_length_returns_none(self):
+        self.assertIsNone(_parse_tm('123'))     # 3 digits -> no format
 
-    def test_unknown_keyword_returns_none(self):
-        self.assertIsNone(self.qf._resolve_tag('NotARealTag'))
-
-
-class QueryFilterApplyTest(TestCase):
-    """
-    These tests exercise the query filter logic against an in-memory queryset.
-    They require a database (model instances) so they use TestCase.
-    """
-
-    def test_unsupported_tag_silently_ignored(self):
-        from pacsfiles.models import PACSSeries
-        qf = QueryFilter(SERIES_FIELDS_BY_TAG)
-        qs = PACSSeries.objects.none()
-        result = qf.apply(qs, QueryDict('99990001=bogus'))
-        # No exception; queryset unchanged
-        self.assertEqual(list(result), [])
-
-    def test_aggregation_tag_skipped(self):
-        from pacsfiles.models import PACSSeries
-        qf = QueryFilter(TAG_MAP_STUDY)
-        qs = PACSSeries.objects.none()
-        # ModalitiesInStudy (00080061) is an Aggregation — must not be applied as filter
-        result = qf.apply(qs, QueryDict('00080061=CT'))
-        self.assertEqual(list(result), [])
-
-    def test_empty_value_skipped(self):
-        from pacsfiles.models import PACSSeries
-        qf = QueryFilter(SERIES_FIELDS_BY_TAG)
-        qs = PACSSeries.objects.none()
-        result = qf.apply(qs, QueryDict('PatientName='))
-        self.assertEqual(list(result), [])
-
-    def test_fuzzymatching_flag_alone_adds_no_filter(self):
-        from pacsfiles.models import PACSSeries
-        qf = QueryFilter(SERIES_FIELDS_BY_TAG)
-        qs = PACSSeries.objects.none()
-        # fuzzymatching is a request-wide modifier, not a match key — on its own
-        # (no PN attribute) it must not raise or apply any filter.
-        result = qf.apply(qs, QueryDict('fuzzymatching=true'))
-        self.assertEqual(list(result), [])
+    def test_invalid_value_returns_none(self):
+        self.assertIsNone(_parse_tm('9999'))    # hour 99 -> ValueError
 
 
-class PaginateTest(TestCase):
+class ParseDtTest(SimpleTestCase):
 
-    def setUp(self):
-        self.qf = QueryFilter(SERIES_FIELDS_BY_TAG)
+    def test_full(self):
+        self.assertEqual(_parse_dt('20230101120000'), datetime(2023, 1, 1, 12, 0, 0))
 
-    def test_limit_enforced(self):
-        from pacsfiles.models import PACSSeries
-        qs = PACSSeries.objects.none()
-        _, _, limit = self.qf.paginate(qs, QueryDict('limit=9999'))
-        self.assertLessEqual(limit, self.qf.HARD_LIMIT)
+    def test_truncated_to_hour(self):
+        # 10-char HH form: must not be mis-parsed by a shorter/longer format.
+        self.assertEqual(_parse_dt('2023010112'), datetime(2023, 1, 1, 12))
 
-    def test_limit_default(self):
-        from pacsfiles.models import PACSSeries
-        qs = PACSSeries.objects.none()
-        _, _, limit = self.qf.paginate(qs, QueryDict(''))
-        self.assertEqual(limit, self.qf.DEFAULT_LIMIT)
+    def test_truncated_to_minute(self):
+        # 12-char HHMM form.
+        self.assertEqual(_parse_dt('202301011230'), datetime(2023, 1, 1, 12, 30))
 
-    def test_invalid_limit_uses_default(self):
-        from pacsfiles.models import PACSSeries
-        qs = PACSSeries.objects.none()
-        _, _, limit = self.qf.paginate(qs, QueryDict('limit=notanumber'))
-        self.assertEqual(limit, self.qf.DEFAULT_LIMIT)
+    def test_date_only(self):
+        self.assertEqual(_parse_dt('20230101'), datetime(2023, 1, 1))
 
-    def test_negative_limit_does_not_crash(self):
-        from pacsfiles.models import PACSSeries
-        qs = PACSSeries.objects.none()
-        page, _, limit = self.qf.paginate(qs, QueryDict('limit=-5'))
-        self.assertEqual(limit, self.qf.DEFAULT_LIMIT)
-        self.assertEqual(list(page), [])  # slicing must not raise on a negative limit
+    def test_fractional_stripped(self):
+        self.assertEqual(_parse_dt('20230101120000.5'), datetime(2023, 1, 1, 12, 0, 0))
+
+    def test_invalid_returns_none(self):
+        self.assertIsNone(_parse_dt('garbage'))
 
 
-class FuzzyMatchingSqlShapeTest(TestCase):
-    """
-    Fuzzy Person-Name matching (PS3.18 §8.3.4.2) must compile to pg_trgm's ``%``
-    similarity operator (Django ``__trigram_similar``), which is GIN-index-backed.
+class ParseTemporalTest(SimpleTestCase):
 
-    Django renders that operator as the escaped literal ``%%`` in the compiled
-    SQL (``TrigramSimilar.postgres_operator``), whereas the exact/wildcard paths
-    (``=``, ``LIKE``, ``~*``) do not — so the presence of ``%%`` is a reliable
-    discriminator for "used the trigram operator".
-    """
+    def test_da(self):
+        self.assertEqual(_parse_temporal('DA', '20230101'), date(2023, 1, 1))
 
-    def setUp(self):
-        self.qf = QueryFilter(SERIES_FIELDS_BY_TAG)
+    def test_tm(self):
+        self.assertEqual(_parse_temporal('TM', '120000'), time(12, 0, 0))
 
-    def _sql(self, querystring):
-        from pacsfiles.models import PACSSeries
-        qs = self.qf.apply(PACSSeries.objects.all(), QueryDict(querystring))
-        sql, _params = qs.query.sql_with_params()
-        return sql
+    def test_dt(self):
+        self.assertEqual(_parse_temporal('DT', '20230101'), datetime(2023, 1, 1))
 
-    def test_fuzzy_pn_uses_trigram_operator(self):
-        self.assertIn('%%', self._sql('PatientName=DOE&fuzzymatching=true'))
-
-    def test_fuzzy_false_uses_exact_not_trigram(self):
-        self.assertNotIn('%%', self._sql('PatientName=DOE&fuzzymatching=false'))
-
-    def test_fuzzy_absent_uses_exact_not_trigram(self):
-        self.assertNotIn('%%', self._sql('PatientName=DOE'))
-
-    def test_fuzzy_true_variants_all_enable_trigram(self):
-        for variant in ('true', '1', 'yes', 'TRUE', 'Yes'):
-            with self.subTest(variant=variant):
-                self.assertIn('%%',
-                              self._sql(f'PatientName=DOE&fuzzymatching={variant}'))
-
-    def test_fuzzy_gated_on_pn_only(self):
-        # Modality (CS VR, fuzzy=False) must not use trigram even with the flag on.
-        self.assertNotIn('%%', self._sql('Modality=CT&fuzzymatching=true'))
-
-    def test_wildcard_takes_precedence_over_fuzzy(self):
-        sql = self._sql('PatientName=DOE*&fuzzymatching=true')
-        self.assertNotIn('%%', sql)   # not the trigram operator
-        self.assertIn('~*', sql)       # the iregex wildcard path
-
-    def test_multivalue_fuzzy_ors_each_value(self):
-        sql = self._sql('PatientName=DOE,SMITH&fuzzymatching=true')
-        self.assertEqual(sql.count('%%'), 2)
+    def test_other_vr_returns_none(self):
+        self.assertIsNone(_parse_temporal('PN', 'DOE^JANE'))
 
 
-class FuzzyMatchingBehaviorTest(TestCase):
-    """
-    End-to-end fuzzy matching against the Postgres test DB, where migration
-    ``0002_pg_trgm`` has created the ``pg_trgm`` extension + GIN indexes and the
-    ``pg_trgm.similarity_threshold`` GUC is set per connection via DATABASES OPTIONS.
-    """
+# ===========================================================================
+# _wildcard_to_regex
+# ===========================================================================
+class WildcardToRegexTest(SimpleTestCase):
 
-    def setUp(self):
-        from datetime import date
-        from django.contrib.auth.models import User
-        from core.models import ChrisFolder
-        from pacsfiles.models import PACS, PACSSeries
+    def test_plain_value_is_anchored(self):
+        self.assertEqual(_wildcard_to_regex('plain'), '^plain$')
 
-        self.user = User.objects.get(username='chris')
-        pacs_folder, _ = ChrisFolder.objects.get_or_create(
-            path='SERVICES/PACS/FUZZPACS', owner=self.user)
-        self.pacs, _ = PACS.objects.get_or_create(
-            folder=pacs_folder, identifier='FUZZPACS')
+    def test_star_becomes_dotstar(self):
+        self.assertEqual(_wildcard_to_regex('DOE*'), '^DOE.*$')
 
-        def make_series(patient_name, series_uid):
-            folder, _ = ChrisFolder.objects.get_or_create(
-                path=f'SERVICES/PACS/FUZZPACS/{series_uid}', owner=self.user)
-            return PACSSeries.objects.create(
-                PatientID='P1', PatientName=patient_name, StudyDate=date(2023, 1, 1),
-                StudyInstanceUID='1.2.3', SeriesInstanceUID=series_uid,
-                folder=folder, pacs=self.pacs)
+    def test_leading_star(self):
+        self.assertEqual(_wildcard_to_regex('*ANNE'), '^.*ANNE$')
 
-        make_series('DOE^JANE', '1.1')
-        make_series('SMITH^JOHN', '1.2')
-        self.qf = QueryFilter(SERIES_FIELDS_BY_TAG)
+    def test_question_becomes_dot(self):
+        self.assertEqual(_wildcard_to_regex('A?C'), '^A.C$')
 
-    # Query 'JOE^JANE' is a one-character transposition of the stored 'DOE^JANE':
-    # literal iexact/istartswith matching misses it, but trigram similarity catches
-    # it — so it cleanly demonstrates what fuzzy adds over literal matching.
-    def test_fuzzy_matches_near_miss_and_excludes_dissimilar(self):
-        from pacsfiles.models import PACSSeries
-        result = self.qf.apply(
-            PACSSeries.objects.all(),
-            QueryDict('PatientName=JOE^JANE&fuzzymatching=true'))
-        names = set(result.values_list('PatientName', flat=True))
-        self.assertIn('DOE^JANE', names)       # near-miss matches
-        self.assertNotIn('SMITH^JOHN', names)  # dissimilar excluded
-
-    def test_non_fuzzy_literal_does_not_match_near_miss(self):
-        from pacsfiles.models import PACSSeries
-        result = self.qf.apply(
-            PACSSeries.objects.all(),
-            QueryDict('PatientName=JOE^JANE'))  # no fuzzymatching → exact/startswith
-        self.assertEqual(list(result.values_list('PatientName', flat=True)), [])
-
-
-class ThresholdGucWiringTest(TestCase):
-    """The DICOMWEB_FUZZY_THRESHOLD setting must reach the DB session as the
-    pg_trgm.similarity_threshold GUC (wired via DATABASES OPTIONS)."""
-
-    def test_similarity_threshold_guc_matches_setting(self):
-        from django.conf import settings
-        from django.db import connection
-        with connection.cursor() as cur:
-            cur.execute('SHOW pg_trgm.similarity_threshold')
-            value = cur.fetchone()[0]
-        self.assertAlmostEqual(float(value), settings.DICOMWEB_FUZZY_THRESHOLD)
-
-
-class GinTrigramIndexTest(TestCase):
-    """Regression guard: migration 0002_pg_trgm must leave the 3 GIN trigram
-    indexes on pacsfiles_pacsseries in place (they back both wildcard and fuzzy)."""
-
-    def test_trgm_indexes_exist(self):
-        from django.db import connection
-        expected = {
-            'pacsseries_patientname_trgm_idx',
-            'pacsseries_patientid_trgm_idx',
-            'pacsseries_studydescription_trgm_idx',
-        }
-        with connection.cursor() as cur:
-            cur.execute(
-                'SELECT indexname FROM pg_indexes WHERE tablename = %s',
-                ['pacsfiles_pacsseries'])
-            names = {row[0] for row in cur.fetchall()}
-        self.assertTrue(expected.issubset(names),
-                        f'missing GIN trigram indexes: {expected - names}')
-
-
-class TemporalAndWildcardBehaviorTest(TestCase):
-    """
-    Behavioral regression guards (against real rows) for parser bugs owned during
-    this PR: wildcard prefix/suffix anchoring, single-value exact DA matching, and
-    TM range matching. See PS3.4 §C.2.2.2 (Attribute Matching).
-    """
-
-    def setUp(self):
-        from django.contrib.auth.models import User
-        from core.models import ChrisFolder
-        from pacsfiles.models import PACS
-
-        self.user = User.objects.get(username='chris')
-        pacs_folder, _ = ChrisFolder.objects.get_or_create(
-            path='SERVICES/PACS/TWPACS', owner=self.user)
-        self.pacs, _ = PACS.objects.get_or_create(
-            folder=pacs_folder, identifier='TWPACS')
-        self._n = 0
-
-    def _series(self, patient_name='X^Y', study_date=None, study_time=None):
-        from datetime import date
-        from core.models import ChrisFolder
-        from pacsfiles.models import PACSSeries
-
-        self._n += 1
-        uid = f'1.2.{self._n}'
-        folder, _ = ChrisFolder.objects.get_or_create(
-            path=f'SERVICES/PACS/TWPACS/{uid}', owner=self.user)
-        return PACSSeries.objects.create(
-            PatientID='P', PatientName=patient_name,
-            StudyDate=study_date or date(2023, 1, 1), StudyTime=study_time,
-            StudyInstanceUID='1.2', SeriesInstanceUID=uid,
-            folder=folder, pacs=self.pacs)
-
-    def test_wildcard_is_prefix_anchored(self):
-        from pacsfiles.models import PACSSeries
-        self._series(patient_name='DOE^JANE')
-        self._series(patient_name='MCDOE^JOHN')  # contains DOE but not a prefix
-        qf = QueryFilter(SERIES_FIELDS_BY_TAG)
-        names = set(qf.apply(PACSSeries.objects.all(),
-                             QueryDict('PatientName=DOE*')).values_list('PatientName', flat=True))
-        self.assertIn('DOE^JANE', names)
-        self.assertNotIn('MCDOE^JOHN', names)  # prefix '*' must not match a substring
-
-    def test_wildcard_is_suffix_anchored(self):
-        from pacsfiles.models import PACSSeries
-        self._series(patient_name='SMITH^ANNE')
-        self._series(patient_name='SMITH^ANNEX')  # ends with X, not ANNE
-        qf = QueryFilter(SERIES_FIELDS_BY_TAG)
-        names = set(qf.apply(PACSSeries.objects.all(),
-                             QueryDict('PatientName=*ANNE')).values_list('PatientName', flat=True))
-        self.assertIn('SMITH^ANNE', names)
-        self.assertNotIn('SMITH^ANNEX', names)
-
-    def test_single_value_exact_date_matches(self):
-        from datetime import date
-        from pacsfiles.models import PACSSeries
-        self._series(study_date=date(2023, 1, 1))
-        self._series(study_date=date(2024, 6, 15))
-        qf = QueryFilter(TAG_MAP_STUDY)
-        got = list(qf.apply(PACSSeries.objects.all(),
-                            QueryDict('StudyDate=20230101')).values_list('StudyDate', flat=True))
-        self.assertEqual(got, [date(2023, 1, 1)])
-
-    def test_time_range_filters(self):
-        from datetime import time
-        from pacsfiles.models import PACSSeries
-        self._series(study_time=time(11, 0, 0))
-        self._series(study_time=time(12, 30, 0))
-        self._series(study_time=time(14, 0, 0))
-        qf = QueryFilter(TAG_MAP_STUDY)
-        got = set(qf.apply(PACSSeries.objects.all(),
-                           QueryDict('StudyTime=120000-130000')).values_list('StudyTime', flat=True))
-        self.assertEqual(got, {time(12, 30, 0)})
-
-# https://dicom.nema.org/medical/dicom/2026b/output/html/part18.html#sect_10.6.1.2.1
-# /studies?PatientID=11235813
-# /studies?PatientID=11235813&StudyDate=20130509
-# /studies?00100010=SMITH*&00101002.00100020=11235813&limit=25
-# /studies?00100010=SMITH*&OtherPatientIDsSequence.00100020=11235813
-# /studies?PatientID=11235813&includefield=00081048,00081049,00081060
-# /studies?PatientID=11235813&includefield=00081048&includefield=00081049&includefield=00081060
-# /studies?PatientID=11235813&StudyDate=20130509-20130510
-# /studies?StudyInstanceUID=1.2.392.200036.9116.2.2.2.2162893313.1029997326.94587,1.2.392.200036.9116.2.2.2.2162893313.1029997326.94583
-# /studies?00230010=AcmeCompany&includefield=00231002&includefield=00231003
-# /studies?00230010=AcmeCompany&00231001=001239&includefield=00231002&includefield=00231003
-
-# https://dicom.nema.org/dicom/2013/output/chtml/part18/sect_6.7.html
-# http://dicomrs/studies​?PatientID=11235813
-# http://dicomrs/studies​?PatientID=11235813​&StudyDate=20130509
-# http://dicomrs/studies​?00100010=SMITH*​&00101002.00100020=11235813​&limit=25
-# http://dicomrs/studies​?00100010=SMITH*​&OtherPatientIDsSequence.00100020=11235813
-# http://dicomrs/studies​?PatientID=11235813​&includefield=00081048​&includefield=00081049​&includefield=00081060
-# http://dicomrs/studies​?PatientID=11235813​&StudyDate=20130509-20130510
-# http://dicomrs/studies​?StudyInstanceUID=1.2.392.200036.9116.2.2.2.2162893313.1029997326.94587​%2c1.2.392.200036.9116.2.2.2.2162893313.1029997326.94583
+    def test_multiple_wildcards(self):
+        self.assertEqual(_wildcard_to_regex('A?C?E*'), '^A.C.E.*$')

--- a/chris_backend/dicomweb/tests/test_query.py
+++ b/chris_backend/dicomweb/tests/test_query.py
@@ -219,7 +219,7 @@ class QueryFilterInitTest(SimpleTestCase):
         self.assertIn(Tag('SeriesNumber'), QueryFilter('series').tag_map)
 
     def test_unknown_resource_type_raises(self):
-        with self.assertRaises(KeyError):
+        with self.assertRaises(ValueError):
             QueryFilter('bogus')
 
 

--- a/chris_backend/dicomweb/tests/test_query.py
+++ b/chris_backend/dicomweb/tests/test_query.py
@@ -19,12 +19,12 @@ from dicomweb.query import (
 class ParseBoolTest(SimpleTestCase):
 
     def test_truthy_values(self):
-        for v in ('true', '1', 'yes', 'TRUE', 'Yes', 'YES'):
+        for v in ('true', '1', 'yes', 'TRUE', 'True', 'Yes', 'YES'):
             with self.subTest(v=v):
                 self.assertTrue(SearchQuery._parse_bool(v))
 
     def test_falsy_values(self):
-        for v in ('false', '0', 'no', '', 'nope'):
+        for v in ('false', '0', 'no', 'FALSE', 'False', 'No', 'NO', '', 'nope'):
             with self.subTest(v=v):
                 self.assertFalse(SearchQuery._parse_bool(v))
 
@@ -59,7 +59,8 @@ class FromQueryDictTest(SimpleTestCase):
                          [Tag('Modality'), Tag('00080061')])
 
     def test_includefield_absent_is_none(self):
-        self.assertIsNone(SearchQuery.from_query_dict(QueryDict('')).includefield)
+        search_query = SearchQuery.from_query_dict(QueryDict(''))
+        self.assertIsNone(search_query.includefield)
 
     def test_limit_and_offset_parsed_as_int(self):
         sq = SearchQuery.from_query_dict(QueryDict('limit=25&offset=10'))
@@ -71,7 +72,9 @@ class FromQueryDictTest(SimpleTestCase):
 
     def test_bool_flags_parsed(self):
         sq = SearchQuery.from_query_dict(QueryDict(
-            'fuzzymatching=true&emptyvaluematching=1&multiplevaluematching=yes'))
+            'fuzzymatching=true'
+            '&emptyvaluematching=1'
+            '&multiplevaluematching=yes'))
         self.assertTrue(sq.fuzzymatching)
         self.assertTrue(sq.emptyvaluematching)
         self.assertTrue(sq.multiplevaluematching)
@@ -171,6 +174,16 @@ class AttributeTest(SimpleTestCase):
         with self.assertRaises(ValueError):
             Attribute('StudyDate').parse_range('20230101')
 
+    def test_parse_range_open_ended(self):
+        open_start = Attribute('StudyDate').parse_range('-20260713')
+        open_end =  Attribute('StudyDate').parse_range('20260713-')
+        self.assertEqual(open_start, RangeValue(None, date(2026,7,13)))
+        self.assertEqual(open_end, RangeValue(date(2026,7,13), None))
+
+    def test_parse_range_no_values_raises(self):
+        with self.assertRaises(ValueError):
+            Attribute('StudyDate').parse_range('-')
+
     def test_parse_multiple_splits_on_comma_and_backslash(self):
         self.assertEqual(Attribute('Modality').parse_multiple('CT,MR').values,
                          ['CT', 'MR'])
@@ -230,8 +243,8 @@ class ApplySqlShapeTest(TestCase):
         return 'WHERE' in str(qs.query)
 
     def test_exact_match_uses_equality(self):
-        sql = self._sql('series', 'PatientName=DOE')
-        self.assertIn('"PatientName" = ', sql)
+        sql = self._sql('series', 'Modality=CT')
+        self.assertIn('"Modality" = ', sql)
 
     def test_unsupported_tag_produces_no_filter(self):
         # Valid-but-unsupported tag (9999,0001) is silently dropped.
@@ -248,10 +261,10 @@ class ApplySqlShapeTest(TestCase):
         # Modality (fuzzy=False) must not use the trigram operator even with the flag.
         self.assertNotIn('%%', self._sql('series', 'Modality=CT&fuzzymatching=true'))
 
-    def test_fuzzy_precedence_over_wildcard(self):
+    def test_wildcard_precedence_over_fuzzy(self):
         # Documented: with fuzzymatching on, a PN value is sent through the fuzzy
         # branch even when it contains a wildcard char (fuzzy is checked first).
-        self.assertIn('%%', self._sql('series', 'PatientName=DOE*&fuzzymatching=true'))
+        self.assertNotIn('%%', self._sql('series', 'PatientName=DOE*&fuzzymatching=true'))
 
     def test_range_emits_gte_and_lte(self):
         sql = self._sql('study', 'StudyDate=20230101-20231231')
@@ -276,7 +289,7 @@ class ApplySqlShapeTest(TestCase):
 
     def test_quoted_empty_matched_with_flag(self):
         sql = self._sql('series', 'PatientName=""&emptyvaluematching=true')
-        self.assertIn('"PatientName" = ', sql)
+        self.assertIn('"PatientName" IS NULL', sql)
 
     def test_distinct_attributes_are_anded(self):
         sql = self._sql('series', 'PatientName=DOE&Modality=CT')
@@ -336,9 +349,14 @@ class ApplyBehaviorTest(TestCase):
                    .values_list('PatientName', flat=True))
 
     def test_exact_match(self):
+        self._series(PatientName='DOE^JANE', Modality='CT')
+        self._series(PatientName='SMITH^JOHN', Modality='MR')
+        self.assertEqual(self._names('Modality=CT'), {'DOE^JANE'})
+
+    def test_pn_match_case(self):
         self._series(PatientName='DOE^JANE')
         self._series(PatientName='SMITH^JOHN')
-        self.assertEqual(self._names('PatientName=DOE^JANE'), {'DOE^JANE'})
+        self.assertEqual(self._names('PatientName=Doe^Jane'), {'DOE^JANE'})
 
     def test_multiple_value_matching(self):
         # No supported field has VM>1, so the multi-value path is exercised via a
@@ -405,13 +423,17 @@ class ApplyBehaviorTest(TestCase):
         self.assertEqual(returned_names, all_names)
 
     def test_empty_value_matching(self):
-        self._series(Modality='', PatientName='EMPTY')
-        self._series(Modality='CT', PatientName='NOT^EMPTY')
+        self._series(Modality='', StudyTime=None, PatientName='EMPTY')
+        self._series(Modality='CT', StudyTime=time(12,0,0), PatientName='NOT^EMPTY')
         self.assertEqual(self._names('Modality=""&emptyvaluematching=true&PatientName=NOT^EMPTY'), set())
         self.assertEqual(self._names('Modality=""&emptyvaluematching=false&PatientName=NOT^EMPTY'), {'NOT^EMPTY'})
         self.assertEqual(self._names('Modality=""&emptyvaluematching=true'), {'EMPTY'})
         self.assertEqual(self._names('Modality=""&emptyvaluematching=false'), {'NOT^EMPTY', 'EMPTY'})
         self.assertEqual(self._names('Modality=""'), {'NOT^EMPTY', 'EMPTY'})
+
+        # Check nullable column
+        self.assertEqual(self._names('StudyTime=""&emptyvaluematching=false', 'study'), {'NOT^EMPTY', 'EMPTY'})
+        self.assertEqual(self._names('StudyTime=""&emptyvaluematching=true', 'study'), {'EMPTY'})
 
 
 # ===========================================================================
@@ -498,12 +520,9 @@ class ParseDaTest(SimpleTestCase):
     def test_truncates_trailing(self):
         self.assertEqual(_parse_da('20230102120000'), date(2023, 1, 2))
 
-    def test_invalid_returns_none(self):
-        self.assertIsNone(_parse_da('not-a-date'))
-
-    def test_empty_returns_none(self):
-        self.assertIsNone(_parse_da(''))
-
+    def test_invalid_raises(self):
+        with self.assertRaises(ValueError):
+            _parse_da('not-a-date')
 
 class ParseTmTest(SimpleTestCase):
 
@@ -519,12 +538,13 @@ class ParseTmTest(SimpleTestCase):
     def test_fractional_seconds_stripped(self):
         self.assertEqual(_parse_tm('120000.500000'), time(12, 0, 0))
 
-    def test_unsupported_length_returns_none(self):
-        self.assertIsNone(_parse_tm('123'))     # 3 digits -> no format
+    def test_unsupported_length_raises(self):
+        with self.assertRaises(ValueError):
+            _parse_tm('123')
 
-    def test_invalid_value_returns_none(self):
-        self.assertIsNone(_parse_tm('9999'))    # hour 99 -> ValueError
-
+    def test_invalid_value_raises(self):
+        with self.assertRaises(ValueError):
+            _parse_tm('9999')
 
 class ParseDtTest(SimpleTestCase):
 
@@ -545,8 +565,9 @@ class ParseDtTest(SimpleTestCase):
     def test_fractional_stripped(self):
         self.assertEqual(_parse_dt('20230101120000.5'), datetime(2023, 1, 1, 12, 0, 0))
 
-    def test_invalid_returns_none(self):
-        self.assertIsNone(_parse_dt('garbage'))
+    def test_invalid_raises(self):
+        with self.assertRaises(ValueError):
+            _parse_dt('garbage')
 
 
 class ParseTemporalTest(SimpleTestCase):
@@ -560,8 +581,9 @@ class ParseTemporalTest(SimpleTestCase):
     def test_dt(self):
         self.assertEqual(_parse_temporal('DT', '20230101'), datetime(2023, 1, 1))
 
-    def test_other_vr_returns_none(self):
-        self.assertIsNone(_parse_temporal('PN', 'DOE^JANE'))
+    def test_other_vr_raises(self):
+        with self.assertRaises(TypeError):
+            _parse_temporal('PN', 'DOE^JANE')
 
 
 # ===========================================================================

--- a/chris_backend/dicomweb/tests/test_query.py
+++ b/chris_backend/dicomweb/tests/test_query.py
@@ -1,0 +1,104 @@
+"""
+Unit tests for dicomweb.query — QIDO-RS DICOM-tag query parser.
+"""
+from django.http import QueryDict
+from django.test import TestCase
+
+from dicomweb.query import QueryFilter, TAG_MAP_SERIES, TAG_MAP_STUDY, _parse_da
+
+
+class ParseDaTest(TestCase):
+
+    def test_valid_date(self):
+        from datetime import date
+        self.assertEqual(_parse_da('20230102'), date(2023, 1, 2))
+
+    def test_invalid_date_returns_none(self):
+        self.assertIsNone(_parse_da('not-a-date'))
+
+    def test_empty_returns_none(self):
+        self.assertIsNone(_parse_da(''))
+
+
+class QueryFilterTagResolutionTest(TestCase):
+
+    def setUp(self):
+        self.qf = QueryFilter(TAG_MAP_SERIES)
+
+    def test_hex_tag_lookup(self):
+        self.assertEqual(self.qf._resolve_tag('00100010'), '00100010')
+
+    def test_keyword_lookup(self):
+        # PatientName keyword → same hex as 00100010
+        self.assertEqual(self.qf._resolve_tag('PatientName'), '00100010')
+
+    def test_lowercase_hex_normalised(self):
+        self.assertEqual(self.qf._resolve_tag('00100010'), '00100010')
+
+    def test_unknown_returns_none(self):
+        self.assertIsNone(self.qf._resolve_tag('99990001'))
+
+    def test_unknown_keyword_returns_none(self):
+        self.assertIsNone(self.qf._resolve_tag('NotARealTag'))
+
+
+class QueryFilterApplyTest(TestCase):
+    """
+    These tests exercise the query filter logic against an in-memory queryset.
+    They require a database (model instances) so they use TestCase.
+    """
+
+    def test_unsupported_tag_silently_ignored(self):
+        from pacsfiles.models import PACSSeries
+        qf = QueryFilter(TAG_MAP_SERIES)
+        qs = PACSSeries.objects.none()
+        result = qf.apply(qs, QueryDict('99990001=bogus'))
+        # No exception; queryset unchanged
+        self.assertEqual(list(result), [])
+
+    def test_aggregation_tag_skipped(self):
+        from pacsfiles.models import PACSSeries
+        qf = QueryFilter(TAG_MAP_STUDY)
+        qs = PACSSeries.objects.none()
+        # ModalitiesInStudy (00080061) is an Aggregation — must not be applied as filter
+        result = qf.apply(qs, QueryDict('00080061=CT'))
+        self.assertEqual(list(result), [])
+
+    def test_empty_value_skipped(self):
+        from pacsfiles.models import PACSSeries
+        qf = QueryFilter(TAG_MAP_SERIES)
+        qs = PACSSeries.objects.none()
+        result = qf.apply(qs, QueryDict('PatientName='))
+        self.assertEqual(list(result), [])
+
+    def test_fuzzymatching_ignored(self):
+        from pacsfiles.models import PACSSeries
+        qf = QueryFilter(TAG_MAP_SERIES)
+        qs = PACSSeries.objects.none()
+        # fuzzymatching is a reserved param — must not raise or apply as filter
+        result = qf.apply(qs, QueryDict('fuzzymatching=true'))
+        self.assertEqual(list(result), [])
+
+
+class PaginateTest(TestCase):
+
+    def setUp(self):
+        self.qf = QueryFilter(TAG_MAP_SERIES)
+
+    def test_limit_enforced(self):
+        from pacsfiles.models import PACSSeries
+        qs = PACSSeries.objects.none()
+        _, _, limit = self.qf.paginate(qs, QueryDict('limit=9999'))
+        self.assertLessEqual(limit, self.qf.HARD_LIMIT)
+
+    def test_limit_default(self):
+        from pacsfiles.models import PACSSeries
+        qs = PACSSeries.objects.none()
+        _, _, limit = self.qf.paginate(qs, QueryDict(''))
+        self.assertEqual(limit, self.qf.DEFAULT_LIMIT)
+
+    def test_invalid_limit_uses_default(self):
+        from pacsfiles.models import PACSSeries
+        qs = PACSSeries.objects.none()
+        _, _, limit = self.qf.paginate(qs, QueryDict('limit=notanumber'))
+        self.assertEqual(limit, self.qf.DEFAULT_LIMIT)

--- a/chris_backend/dicomweb/tests/test_query.py
+++ b/chris_backend/dicomweb/tests/test_query.py
@@ -71,11 +71,12 @@ class QueryFilterApplyTest(TestCase):
         result = qf.apply(qs, QueryDict('PatientName='))
         self.assertEqual(list(result), [])
 
-    def test_fuzzymatching_ignored(self):
+    def test_fuzzymatching_flag_alone_adds_no_filter(self):
         from pacsfiles.models import PACSSeries
         qf = QueryFilter(TAG_MAP_SERIES)
         qs = PACSSeries.objects.none()
-        # fuzzymatching is a reserved param — must not raise or apply as filter
+        # fuzzymatching is a request-wide modifier, not a match key — on its own
+        # (no PN attribute) it must not raise or apply any filter.
         result = qf.apply(qs, QueryDict('fuzzymatching=true'))
         self.assertEqual(list(result), [])
 
@@ -102,3 +103,136 @@ class PaginateTest(TestCase):
         qs = PACSSeries.objects.none()
         _, _, limit = self.qf.paginate(qs, QueryDict('limit=notanumber'))
         self.assertEqual(limit, self.qf.DEFAULT_LIMIT)
+
+
+class FuzzyMatchingSqlShapeTest(TestCase):
+    """
+    Fuzzy Person-Name matching (PS3.18 §8.3.4.2) must compile to pg_trgm's ``%``
+    similarity operator (Django ``__trigram_similar``), which is GIN-index-backed.
+
+    Django renders that operator as the escaped literal ``%%`` in the compiled
+    SQL (``TrigramSimilar.postgres_operator``), whereas the exact/wildcard paths
+    (``=``, ``LIKE``, ``~*``) do not — so the presence of ``%%`` is a reliable
+    discriminator for "used the trigram operator".
+    """
+
+    def setUp(self):
+        self.qf = QueryFilter(TAG_MAP_SERIES)
+
+    def _sql(self, querystring):
+        from pacsfiles.models import PACSSeries
+        qs = self.qf.apply(PACSSeries.objects.all(), QueryDict(querystring))
+        sql, _params = qs.query.sql_with_params()
+        return sql
+
+    def test_fuzzy_pn_uses_trigram_operator(self):
+        self.assertIn('%%', self._sql('PatientName=DOE&fuzzymatching=true'))
+
+    def test_fuzzy_false_uses_exact_not_trigram(self):
+        self.assertNotIn('%%', self._sql('PatientName=DOE&fuzzymatching=false'))
+
+    def test_fuzzy_absent_uses_exact_not_trigram(self):
+        self.assertNotIn('%%', self._sql('PatientName=DOE'))
+
+    def test_fuzzy_true_variants_all_enable_trigram(self):
+        for variant in ('true', '1', 'yes', 'TRUE', 'Yes'):
+            with self.subTest(variant=variant):
+                self.assertIn('%%',
+                              self._sql(f'PatientName=DOE&fuzzymatching={variant}'))
+
+    def test_fuzzy_gated_on_pn_only(self):
+        # Modality (CS VR, fuzzy=False) must not use trigram even with the flag on.
+        self.assertNotIn('%%', self._sql('Modality=CT&fuzzymatching=true'))
+
+    def test_wildcard_takes_precedence_over_fuzzy(self):
+        sql = self._sql('PatientName=DOE*&fuzzymatching=true')
+        self.assertNotIn('%%', sql)   # not the trigram operator
+        self.assertIn('~*', sql)       # the iregex wildcard path
+
+    def test_multivalue_fuzzy_ors_each_value(self):
+        sql = self._sql('PatientName=DOE,SMITH&fuzzymatching=true')
+        self.assertEqual(sql.count('%%'), 2)
+
+
+class FuzzyMatchingBehaviorTest(TestCase):
+    """
+    End-to-end fuzzy matching against the Postgres test DB, where migration
+    ``0002_pg_trgm`` has created the ``pg_trgm`` extension + GIN indexes and the
+    ``pg_trgm.similarity_threshold`` GUC is set per connection via DATABASES OPTIONS.
+    """
+
+    def setUp(self):
+        from datetime import date
+        from django.contrib.auth.models import User
+        from core.models import ChrisFolder
+        from pacsfiles.models import PACS, PACSSeries
+
+        self.user = User.objects.get(username='chris')
+        pacs_folder, _ = ChrisFolder.objects.get_or_create(
+            path='SERVICES/PACS/FUZZPACS', owner=self.user)
+        self.pacs, _ = PACS.objects.get_or_create(
+            folder=pacs_folder, identifier='FUZZPACS')
+
+        def make_series(patient_name, series_uid):
+            folder, _ = ChrisFolder.objects.get_or_create(
+                path=f'SERVICES/PACS/FUZZPACS/{series_uid}', owner=self.user)
+            return PACSSeries.objects.create(
+                PatientID='P1', PatientName=patient_name, StudyDate=date(2023, 1, 1),
+                StudyInstanceUID='1.2.3', SeriesInstanceUID=series_uid,
+                folder=folder, pacs=self.pacs)
+
+        make_series('DOE^JANE', '1.1')
+        make_series('SMITH^JOHN', '1.2')
+        self.qf = QueryFilter(TAG_MAP_SERIES)
+
+    # Query 'JOE^JANE' is a one-character transposition of the stored 'DOE^JANE':
+    # literal iexact/istartswith matching misses it, but trigram similarity catches
+    # it — so it cleanly demonstrates what fuzzy adds over literal matching.
+    def test_fuzzy_matches_near_miss_and_excludes_dissimilar(self):
+        from pacsfiles.models import PACSSeries
+        result = self.qf.apply(
+            PACSSeries.objects.all(),
+            QueryDict('PatientName=JOE^JANE&fuzzymatching=true'))
+        names = set(result.values_list('PatientName', flat=True))
+        self.assertIn('DOE^JANE', names)       # near-miss matches
+        self.assertNotIn('SMITH^JOHN', names)  # dissimilar excluded
+
+    def test_non_fuzzy_literal_does_not_match_near_miss(self):
+        from pacsfiles.models import PACSSeries
+        result = self.qf.apply(
+            PACSSeries.objects.all(),
+            QueryDict('PatientName=JOE^JANE'))  # no fuzzymatching → exact/startswith
+        self.assertEqual(list(result.values_list('PatientName', flat=True)), [])
+
+
+class ThresholdGucWiringTest(TestCase):
+    """The DICOMWEB_FUZZY_THRESHOLD setting must reach the DB session as the
+    pg_trgm.similarity_threshold GUC (wired via DATABASES OPTIONS)."""
+
+    def test_similarity_threshold_guc_matches_setting(self):
+        from django.conf import settings
+        from django.db import connection
+        with connection.cursor() as cur:
+            cur.execute('SHOW pg_trgm.similarity_threshold')
+            value = cur.fetchone()[0]
+        self.assertAlmostEqual(float(value), settings.DICOMWEB_FUZZY_THRESHOLD)
+
+
+class GinTrigramIndexTest(TestCase):
+    """Regression guard: migration 0002_pg_trgm must leave the 3 GIN trigram
+    indexes on pacsfiles_pacsseries in place (they back both wildcard and fuzzy)."""
+
+    def test_trgm_indexes_exist(self):
+        from django.db import connection
+        expected = {
+            'pacsseries_patientname_trgm_idx',
+            'pacsseries_patientid_trgm_idx',
+            'pacsseries_studydescription_trgm_idx',
+        }
+        with connection.cursor() as cur:
+            cur.execute(
+                'SELECT indexname FROM pg_indexes WHERE tablename = %s',
+                ['pacsfiles_pacsseries'])
+            names = {row[0] for row in cur.fetchall()}
+        self.assertTrue(expected.issubset(names),
+                        f'missing GIN trigram indexes: {expected - names}')

--- a/chris_backend/dicomweb/tests/test_query.py
+++ b/chris_backend/dicomweb/tests/test_query.py
@@ -272,9 +272,10 @@ class ApplySqlShapeTest(TestCase):
         self.assertIn('<=', sql)
 
     def test_multiple_value_emits_in(self):
-        # No supported field has VM>1, so the multi-value IN path is unreachable
-        # through the resource maps. Drive it with a genuinely multi-valued
-        # attribute (ModalitiesInStudy, CS VM 1-n) mapped onto a real column.
+        # The multiplevaluematching-gated multi path (VR in MULTI_VALUE_VRS with
+        # VM>1) has no such field in the resource maps, so drive it with a
+        # synthetic ModalitiesInStudy (CS VM 1-n) mapped onto a real column. The
+        # ungated UID-list IN path is covered separately by the real-map tests.
         from pacsfiles.models import PACSSeries
         attr = Attribute('ModalitiesInStudy', orm_field='Modality')
         qf = QueryFilter('series')
@@ -305,10 +306,38 @@ class ApplySqlShapeTest(TestCase):
         self.assertIn('pacsfiles_pacsseries', sql)          # joined series table
         self.assertIn('"SeriesInstanceUID" = ', sql)
 
+    def test_instance_empty_value_follows_fk_relation(self):
+        # Empty-value matching on the instance map's series__ pass-through field
+        # must follow the FK relation to resolve the target column type. This is
+        # the only path that reaches the relation-following branch of
+        # _is_text_column; SeriesInstanceUID is text, so the compiled filter is
+        # the NULL-or-empty pair (`IS NULL` OR `= ''`).
+        from dicomweb.models import PACSInstance
+        qf = QueryFilter('instance')
+        sq = SearchQuery.from_query_dict(
+            QueryDict('SeriesInstanceUID=""&emptyvaluematching=true'))
+        sql, params = qf.apply(PACSInstance.objects.all(), sq).query.sql_with_params()
+        self.assertIn('"SeriesInstanceUID" IS NULL', sql)
+        self.assertIn(' OR ', sql)          # text column → empty-string alternative
+        self.assertIn('"SeriesInstanceUID" = ', sql)
+        self.assertIn('', params)
+
+    def test_uid_list_emits_in(self):
+        self.assertIn('IN (', self._sql('study', 'StudyInstanceUID=1.2.3,4.5.6'))
+
+    def test_uid_list_emits_in_on_instance_passthrough(self):
+        # Same ungated UID-list path through the instance map's
+        # series__StudyInstanceUID FK pass-through field.
+        from dicomweb.models import PACSInstance
+        qf = QueryFilter('instance')
+        sq = SearchQuery.from_query_dict(QueryDict('StudyInstanceUID=1.2.3,4.5.6'))
+        sql = qf.apply(PACSInstance.objects.all(), sq).query.sql_with_params()[0]
+        self.assertIn('IN (', sql)
+
     def test_temporal_empty_is_universal_matching(self):
         # PS3.4 §C.2.2.2.3: a zero-length value is universal matching (no
-        # restriction) — including temporal VRs, whose empty value parses to
-        # None and must not emit `StudyDate IS NULL`.
+        # restriction) — including temporal VRs, whose empty value yields a
+        # UniversalValue sentinel and must not emit `StudyDate IS NULL`.
         self.assertFalse(self._has_where('study', 'StudyDate='))
 
 
@@ -359,9 +388,10 @@ class ApplyBehaviorTest(TestCase):
         self.assertEqual(self._names('PatientName=Doe^Jane'), {'DOE^JANE'})
 
     def test_multiple_value_matching(self):
-        # No supported field has VM>1, so the multi-value path is exercised via a
-        # genuinely multi-valued attribute (ModalitiesInStudy, CS VM 1-n) mapped
-        # onto the real Modality column.
+        # The multiplevaluematching-gated multi path (VR in MULTI_VALUE_VRS with
+        # VM>1) has no such field in the resource maps, so it is exercised via a
+        # synthetic ModalitiesInStudy (CS VM 1-n) mapped onto the real Modality
+        # column. The ungated UID-list path is covered by test_uid_list_* above.
         from pacsfiles.models import PACSSeries
         self._series(PatientName='A', Modality='CT')
         self._series(PatientName='B', Modality='MR')
@@ -374,6 +404,15 @@ class ApplyBehaviorTest(TestCase):
         names = set(qf.apply(PACSSeries.objects.all(), sq)
                     .values_list('PatientName', flat=True))
         self.assertEqual(names, {'A', 'B'})
+
+    def test_uid_list_matches_multiple_rows(self):
+        # StudyInstanceUID=<uid>,<uid> (UI VR, ungated IN path via UID_LIST_VRS)
+        # matches every listed study
+        self._series(PatientName='A', StudyInstanceUID='1')
+        self._series(PatientName='B', StudyInstanceUID='2')
+        self._series(PatientName='C', StudyInstanceUID='3')
+        self.assertEqual(self._names('StudyInstanceUID=1,2', 'study'),
+                         {'A', 'B'})
 
     def test_date_range_matching(self):
         self._series(PatientName='IN', StudyDate=date(2023, 6, 1))

--- a/chris_backend/dicomweb/tests/test_query.py
+++ b/chris_backend/dicomweb/tests/test_query.py
@@ -104,6 +104,13 @@ class PaginateTest(TestCase):
         _, _, limit = self.qf.paginate(qs, QueryDict('limit=notanumber'))
         self.assertEqual(limit, self.qf.DEFAULT_LIMIT)
 
+    def test_negative_limit_does_not_crash(self):
+        from pacsfiles.models import PACSSeries
+        qs = PACSSeries.objects.none()
+        page, _, limit = self.qf.paginate(qs, QueryDict('limit=-5'))
+        self.assertEqual(limit, self.qf.DEFAULT_LIMIT)
+        self.assertEqual(list(page), [])  # slicing must not raise on a negative limit
+
 
 class FuzzyMatchingSqlShapeTest(TestCase):
     """
@@ -236,3 +243,79 @@ class GinTrigramIndexTest(TestCase):
             names = {row[0] for row in cur.fetchall()}
         self.assertTrue(expected.issubset(names),
                         f'missing GIN trigram indexes: {expected - names}')
+
+
+class TemporalAndWildcardBehaviorTest(TestCase):
+    """
+    Behavioral regression guards (against real rows) for parser bugs owned during
+    this PR: wildcard prefix/suffix anchoring, single-value exact DA matching, and
+    TM range matching. See PS3.4 §C.2.2.2 (Attribute Matching).
+    """
+
+    def setUp(self):
+        from django.contrib.auth.models import User
+        from core.models import ChrisFolder
+        from pacsfiles.models import PACS
+
+        self.user = User.objects.get(username='chris')
+        pacs_folder, _ = ChrisFolder.objects.get_or_create(
+            path='SERVICES/PACS/TWPACS', owner=self.user)
+        self.pacs, _ = PACS.objects.get_or_create(
+            folder=pacs_folder, identifier='TWPACS')
+        self._n = 0
+
+    def _series(self, patient_name='X^Y', study_date=None, study_time=None):
+        from datetime import date
+        from core.models import ChrisFolder
+        from pacsfiles.models import PACSSeries
+
+        self._n += 1
+        uid = f'1.2.{self._n}'
+        folder, _ = ChrisFolder.objects.get_or_create(
+            path=f'SERVICES/PACS/TWPACS/{uid}', owner=self.user)
+        return PACSSeries.objects.create(
+            PatientID='P', PatientName=patient_name,
+            StudyDate=study_date or date(2023, 1, 1), StudyTime=study_time,
+            StudyInstanceUID='1.2', SeriesInstanceUID=uid,
+            folder=folder, pacs=self.pacs)
+
+    def test_wildcard_is_prefix_anchored(self):
+        from pacsfiles.models import PACSSeries
+        self._series(patient_name='DOE^JANE')
+        self._series(patient_name='MCDOE^JOHN')  # contains DOE but not a prefix
+        qf = QueryFilter(TAG_MAP_SERIES)
+        names = set(qf.apply(PACSSeries.objects.all(),
+                             QueryDict('PatientName=DOE*')).values_list('PatientName', flat=True))
+        self.assertIn('DOE^JANE', names)
+        self.assertNotIn('MCDOE^JOHN', names)  # prefix '*' must not match a substring
+
+    def test_wildcard_is_suffix_anchored(self):
+        from pacsfiles.models import PACSSeries
+        self._series(patient_name='SMITH^ANNE')
+        self._series(patient_name='SMITH^ANNEX')  # ends with X, not ANNE
+        qf = QueryFilter(TAG_MAP_SERIES)
+        names = set(qf.apply(PACSSeries.objects.all(),
+                             QueryDict('PatientName=*ANNE')).values_list('PatientName', flat=True))
+        self.assertIn('SMITH^ANNE', names)
+        self.assertNotIn('SMITH^ANNEX', names)
+
+    def test_single_value_exact_date_matches(self):
+        from datetime import date
+        from pacsfiles.models import PACSSeries
+        self._series(study_date=date(2023, 1, 1))
+        self._series(study_date=date(2024, 6, 15))
+        qf = QueryFilter(TAG_MAP_STUDY)
+        got = list(qf.apply(PACSSeries.objects.all(),
+                            QueryDict('StudyDate=20230101')).values_list('StudyDate', flat=True))
+        self.assertEqual(got, [date(2023, 1, 1)])
+
+    def test_time_range_filters(self):
+        from datetime import time
+        from pacsfiles.models import PACSSeries
+        self._series(study_time=time(11, 0, 0))
+        self._series(study_time=time(12, 30, 0))
+        self._series(study_time=time(14, 0, 0))
+        qf = QueryFilter(TAG_MAP_STUDY)
+        got = set(qf.apply(PACSSeries.objects.all(),
+                           QueryDict('StudyTime=120000-130000')).values_list('StudyTime', flat=True))
+        self.assertEqual(got, {time(12, 30, 0)})

--- a/chris_backend/dicomweb/tests/test_query.py
+++ b/chris_backend/dicomweb/tests/test_query.py
@@ -277,14 +277,20 @@ class ApplySqlShapeTest(TestCase):
         # VM>1) has no such field in the resource maps, so drive it with a
         # synthetic ModalitiesInStudy (CS VM 1-n) mapped onto a real column. The
         # ungated UID-list IN path is covered separately by the real-map tests.
-        from pacsfiles.models import PACSSeries
-        attr = Attribute('ModalitiesInStudy', orm_field='Modality')
-        qf = QueryFilter('series')
+        from dicomweb.models import PACSStudy
+        qf = QueryFilter('study')
+
+        # TODO: remove monkeypatch after ModalitiesInStudy implemented
+        attr = Attribute('ModalitiesInStudy', orm_field='PatientName')
         qf.tag_map = {attr.tag: attr}
+
         sq = SearchQuery.from_query_dict(
             QueryDict('ModalitiesInStudy=CT,MR&multiplevaluematching=true'))
-        sql = qf.apply(PACSSeries.objects.all(), sq).query.sql_with_params()[0]
-        self.assertIn('IN (', sql)
+        sql, params = qf.apply(PACSStudy.objects.all(), sq).query.sql_with_params()
+        self.assertIn(' AND ', sql)
+        self.assertIn(' LIKE ', sql)
+        self.assertIn('%CT%', params)
+        self.assertIn('%MR%', params)
 
     def test_quoted_empty_skipped_without_flag(self):
         self.assertFalse(self._has_where('series', 'PatientName=""'))
@@ -419,9 +425,8 @@ class ApplyBehaviorTest(TestCase):
         # multi-value matching path.
         # TODO: remove this once the above expected failure is passing
         from pacsfiles.models import PACSSeries
-        self._series(PatientName='A', Modality='CT')
-        self._series(PatientName='B', Modality='MR')
-        self._series(PatientName='C', Modality='US')
+        self._series(PatientName='A', StudyInstanceUID='A.1', Modality=r'CT\MR')
+        self._series(PatientName='B', StudyInstanceUID='B.1', Modality=r'US')
         attr = Attribute('ModalitiesInStudy', orm_field='Modality')
         qf = QueryFilter('series')
         qf.tag_map = {attr.tag: attr}
@@ -429,7 +434,7 @@ class ApplyBehaviorTest(TestCase):
             QueryDict('ModalitiesInStudy=CT,MR&multiplevaluematching=true'))
         names = set(qf.apply(PACSSeries.objects.all(), sq)
                     .values_list('PatientName', flat=True))
-        self.assertEqual(names, {'A', 'B'})
+        self.assertEqual(names, {'A'})
 
     def test_uid_list_matches_multiple_rows(self):
         # StudyInstanceUID=<uid>,<uid> (UI VR, ungated IN path via UID_LIST_VRS)

--- a/chris_backend/dicomweb/tests/test_query.py
+++ b/chris_backend/dicomweb/tests/test_query.py
@@ -3,6 +3,7 @@ Unit tests for ``dicomweb.query`` — the QIDO-RS DICOM-tag query parser
 (PS3.18 §10.6 Search Transaction; matching semantics per PS3.4 §C.2.2.2).
 """
 from datetime import date, time, datetime
+import unittest
 
 from django.http import QueryDict
 from django.test import TestCase, SimpleTestCase
@@ -370,6 +371,13 @@ class ApplyBehaviorTest(TestCase):
         fields.update(overrides)
         return PACSSeries.objects.create(**fields)
 
+    def _study(self, **overrides):
+        from dicomweb.models import PACSStudy
+        fields = dict(PatientID='P', PatientName='X^Y', StudyDate=date(2023, 1, 1),
+                      StudyInstanceUID='1.2', pacs=self.pacs)
+        fields.update(overrides)
+        return PACSStudy.objects.create(**fields)
+
     def _names(self, querystring, resource='series'):
         from pacsfiles.models import PACSSeries
         qf = QueryFilter(resource)
@@ -387,11 +395,29 @@ class ApplyBehaviorTest(TestCase):
         self._series(PatientName='SMITH^JOHN')
         self.assertEqual(self._names('PatientName=Doe^Jane'), {'DOE^JANE'})
 
+    @unittest.expectedFailure   # ModalitiesInStudy missing
     def test_multiple_value_matching(self):
-        # The multiplevaluematching-gated multi path (VR in MULTI_VALUE_VRS with
-        # VM>1) has no such field in the resource maps, so it is exercised via a
-        # synthetic ModalitiesInStudy (CS VM 1-n) mapped onto the real Modality
-        # column. The ungated UID-list path is covered by test_uid_list_* above.
+        # multiple value matching asserts that all values of a
+        # comma-separated list appear in the matched object. We can
+        # test this by querying multiple values on ModalitiesInStudy.
+        # We should only get back studies that series with all modalities
+        from dicomweb.models import PACSStudy
+        self._study(PatientName='A', StudyInstanceUID='A.1', ModalitiesInStudy=r'CT\MR')
+        self._study(PatientName='A', StudyInstanceUID='A.2', ModalitiesInStudy=r'CT')
+        self._study(PatientName='A', StudyInstanceUID='A.3', ModalitiesInStudy=r'PT')
+        self._study(PatientName='B', StudyInstanceUID='B.3', ModalitiesInStudy=r'CT')
+        self._study(PatientName='B', StudyInstanceUID='B.3', ModalitiesInStudy=r'MR')
+        qf = QueryFilter('study')
+        sq = SearchQuery.from_query_dict(
+            QueryDict('ModalitiesInStudy=CT,MR&multiplevaluematching=true'))
+        study_instance_uids = set(qf.apply(PACSStudy.objects.all(), sq)
+                                  .values_list('StudyInstanceUID', flat=True))
+        self.assertEqual(study_instance_uids, {'A.1'})
+
+    def test_multiple_value_matching_monkeypatch(self):
+        # Workaround to exercise the currently-inaccessible
+        # multi-value matching path.
+        # TODO: remove this once the above expected failure is passing
         from pacsfiles.models import PACSSeries
         self._series(PatientName='A', Modality='CT')
         self._series(PatientName='B', Modality='MR')

--- a/chris_backend/dicomweb/tests/test_query.py
+++ b/chris_backend/dicomweb/tests/test_query.py
@@ -4,7 +4,7 @@ Unit tests for dicomweb.query — QIDO-RS DICOM-tag query parser.
 from django.http import QueryDict
 from django.test import TestCase
 
-from dicomweb.query import QueryFilter, TAG_MAP_SERIES, TAG_MAP_STUDY, _parse_da
+from dicomweb.query import QueryFilter, SERIES_FIELDS_BY_TAG, TAG_MAP_STUDY, _parse_da
 
 
 class ParseDaTest(TestCase):
@@ -23,7 +23,7 @@ class ParseDaTest(TestCase):
 class QueryFilterTagResolutionTest(TestCase):
 
     def setUp(self):
-        self.qf = QueryFilter(TAG_MAP_SERIES)
+        self.qf = QueryFilter(SERIES_FIELDS_BY_TAG)
 
     def test_hex_tag_lookup(self):
         self.assertEqual(self.qf._resolve_tag('00100010'), '00100010')
@@ -50,7 +50,7 @@ class QueryFilterApplyTest(TestCase):
 
     def test_unsupported_tag_silently_ignored(self):
         from pacsfiles.models import PACSSeries
-        qf = QueryFilter(TAG_MAP_SERIES)
+        qf = QueryFilter(SERIES_FIELDS_BY_TAG)
         qs = PACSSeries.objects.none()
         result = qf.apply(qs, QueryDict('99990001=bogus'))
         # No exception; queryset unchanged
@@ -66,14 +66,14 @@ class QueryFilterApplyTest(TestCase):
 
     def test_empty_value_skipped(self):
         from pacsfiles.models import PACSSeries
-        qf = QueryFilter(TAG_MAP_SERIES)
+        qf = QueryFilter(SERIES_FIELDS_BY_TAG)
         qs = PACSSeries.objects.none()
         result = qf.apply(qs, QueryDict('PatientName='))
         self.assertEqual(list(result), [])
 
     def test_fuzzymatching_flag_alone_adds_no_filter(self):
         from pacsfiles.models import PACSSeries
-        qf = QueryFilter(TAG_MAP_SERIES)
+        qf = QueryFilter(SERIES_FIELDS_BY_TAG)
         qs = PACSSeries.objects.none()
         # fuzzymatching is a request-wide modifier, not a match key — on its own
         # (no PN attribute) it must not raise or apply any filter.
@@ -84,7 +84,7 @@ class QueryFilterApplyTest(TestCase):
 class PaginateTest(TestCase):
 
     def setUp(self):
-        self.qf = QueryFilter(TAG_MAP_SERIES)
+        self.qf = QueryFilter(SERIES_FIELDS_BY_TAG)
 
     def test_limit_enforced(self):
         from pacsfiles.models import PACSSeries
@@ -124,7 +124,7 @@ class FuzzyMatchingSqlShapeTest(TestCase):
     """
 
     def setUp(self):
-        self.qf = QueryFilter(TAG_MAP_SERIES)
+        self.qf = QueryFilter(SERIES_FIELDS_BY_TAG)
 
     def _sql(self, querystring):
         from pacsfiles.models import PACSSeries
@@ -190,7 +190,7 @@ class FuzzyMatchingBehaviorTest(TestCase):
 
         make_series('DOE^JANE', '1.1')
         make_series('SMITH^JOHN', '1.2')
-        self.qf = QueryFilter(TAG_MAP_SERIES)
+        self.qf = QueryFilter(SERIES_FIELDS_BY_TAG)
 
     # Query 'JOE^JANE' is a one-character transposition of the stored 'DOE^JANE':
     # literal iexact/istartswith matching misses it, but trigram similarity catches
@@ -283,7 +283,7 @@ class TemporalAndWildcardBehaviorTest(TestCase):
         from pacsfiles.models import PACSSeries
         self._series(patient_name='DOE^JANE')
         self._series(patient_name='MCDOE^JOHN')  # contains DOE but not a prefix
-        qf = QueryFilter(TAG_MAP_SERIES)
+        qf = QueryFilter(SERIES_FIELDS_BY_TAG)
         names = set(qf.apply(PACSSeries.objects.all(),
                              QueryDict('PatientName=DOE*')).values_list('PatientName', flat=True))
         self.assertIn('DOE^JANE', names)
@@ -293,7 +293,7 @@ class TemporalAndWildcardBehaviorTest(TestCase):
         from pacsfiles.models import PACSSeries
         self._series(patient_name='SMITH^ANNE')
         self._series(patient_name='SMITH^ANNEX')  # ends with X, not ANNE
-        qf = QueryFilter(TAG_MAP_SERIES)
+        qf = QueryFilter(SERIES_FIELDS_BY_TAG)
         names = set(qf.apply(PACSSeries.objects.all(),
                              QueryDict('PatientName=*ANNE')).values_list('PatientName', flat=True))
         self.assertIn('SMITH^ANNE', names)
@@ -319,3 +319,24 @@ class TemporalAndWildcardBehaviorTest(TestCase):
         got = set(qf.apply(PACSSeries.objects.all(),
                            QueryDict('StudyTime=120000-130000')).values_list('StudyTime', flat=True))
         self.assertEqual(got, {time(12, 30, 0)})
+
+# https://dicom.nema.org/medical/dicom/2026b/output/html/part18.html#sect_10.6.1.2.1
+# /studies?PatientID=11235813
+# /studies?PatientID=11235813&StudyDate=20130509
+# /studies?00100010=SMITH*&00101002.00100020=11235813&limit=25
+# /studies?00100010=SMITH*&OtherPatientIDsSequence.00100020=11235813
+# /studies?PatientID=11235813&includefield=00081048,00081049,00081060
+# /studies?PatientID=11235813&includefield=00081048&includefield=00081049&includefield=00081060
+# /studies?PatientID=11235813&StudyDate=20130509-20130510
+# /studies?StudyInstanceUID=1.2.392.200036.9116.2.2.2.2162893313.1029997326.94587,1.2.392.200036.9116.2.2.2.2162893313.1029997326.94583
+# /studies?00230010=AcmeCompany&includefield=00231002&includefield=00231003
+# /studies?00230010=AcmeCompany&00231001=001239&includefield=00231002&includefield=00231003
+
+# https://dicom.nema.org/dicom/2013/output/chtml/part18/sect_6.7.html
+# http://dicomrs/studies​?PatientID=11235813
+# http://dicomrs/studies​?PatientID=11235813​&StudyDate=20130509
+# http://dicomrs/studies​?00100010=SMITH*​&00101002.00100020=11235813​&limit=25
+# http://dicomrs/studies​?00100010=SMITH*​&OtherPatientIDsSequence.00100020=11235813
+# http://dicomrs/studies​?PatientID=11235813​&includefield=00081048​&includefield=00081049​&includefield=00081060
+# http://dicomrs/studies​?PatientID=11235813​&StudyDate=20130509-20130510
+# http://dicomrs/studies​?StudyInstanceUID=1.2.392.200036.9116.2.2.2.2162893313.1029997326.94587​%2c1.2.392.200036.9116.2.2.2.2162893313.1029997326.94583


### PR DESCRIPTION
## Summary

Implements `dicomweb/query.py` — the QIDO-RS query parser that translates URL query parameters into Django ORM filters (PS3.18 §10.6 Search Transaction; matching semantics per PS3.4 §C.2.2.2).

- **`SearchQuery.from_query_dict()`** — parses a `QueryDict` into a structured query: match keys, `includefield`, `limit`/`offset`, and the `fuzzymatching` / `emptyvaluematching` / `multiplevaluematching` flags.
- **`QueryFilter(resource_type)`** with `apply()` and `paginate()`, backed by resource-typed attribute maps for the `study`, `series`, and `instance` levels.
- Tag resolution by hex (`00100010`) or DICOM keyword (`PatientName`).
- Matching types (PS3.4 §C.2.2.2): single-value, wildcard (`*`/`?`), date/time ranges, multi-value, universal (zero-length value), and empty-value (`""`).
- `includefield` accepts `all`, repeated parameters, and comma-separated lists.
- `limit`/`offset` pagination; `limit` capped at 5000 (default 50).
- Unknown/unsupported tags are silently dropped (PS3.4).
- `dicomweb/tests/test_query.py` — unit tests for the parser.

### Fuzzy Person-Name matching

Fuzzy PN matching (PS3.18 §8.3.4.2 / PS3.4 §C.2.2.2.1.1) compiles to pg_trgm's `%` similarity operator (Django `__trigram_similar`), which is served by the GIN trigram indexes already on `master`. The similarity threshold is configurable per deployment via the new `DICOMWEB_FUZZY_THRESHOLD` setting, applied as the per-connection `pg_trgm.similarity_threshold` GUC (`django.contrib.postgres` is added to `INSTALLED_APPS`).

Planning: [ATLAS-planning#109](https://github.com/FNNDSC/ATLAS-planning/issues/109)

## Test plan

```bash
just test dicomweb --exclude-tag integration
```

## Merge requirements

All items below must be satisfied before merge. (GitHub does not allow approvals on draft PRs — mark ready, collect approval, then merge.)

- [x] **Codacy — coverage ≥ 100%** on all new `dicomweb/` code introduced in this branch (`just test dicomweb` coverage report green)
- [x] **Codacy — complexity** all new functions/methods at cyclomatic complexity ≤ configured threshold; refactor any flagged hotspots before merge
- [x] **Codacy — issues resolved** zero open Codacy findings (Error Prone, Security, Code Style, Duplication) on this branch's diff
- [ ] **Human review resolved** all reviewer comments addressed and marked resolved; at least one approval from someone other than the last pusher (branch protection)